### PR TITLE
Fix stakeholder display issues with missing photoURL or displayName

### DIFF
--- a/app/organisation/[organisationId]/decision/[id]/identify/page.tsx
+++ b/app/organisation/[organisationId]/decision/[id]/identify/page.tsx
@@ -229,9 +229,11 @@ export default function DecisionIdentityPage() {
                                 />
                                 <AvatarFallback>
                                   {driverStakeholder?.displayName
-                                    ?.split(" ")
-                                    .map((n) => n[0])
-                                    .join("") || "?"}
+                                    ? driverStakeholder.displayName
+                                        .split(" ")
+                                        .map((n) => n[0])
+                                        .join("")
+                                    : "👤"}
                                 </AvatarFallback>
                               </Avatar>
                               {driverStakeholder?.displayName}
@@ -269,7 +271,7 @@ export default function DecisionIdentityPage() {
                                     .split(" ")
                                     .map((n) => n[0])
                                     .join("")
-                                : "?"}
+                                : "👤"}
                             </AvatarFallback>
                           </Avatar>
                           {stakeholder.displayName}

--- a/components/StakeholderManagement.tsx
+++ b/components/StakeholderManagement.tsx
@@ -340,10 +340,12 @@ export function StakeholderManagement({ organisationId }: StakeholderManagementP
                         <AvatarImage src={stakeholder.photoURL} />
                         <AvatarFallback>
                           {stakeholder.displayName
-                            .split(' ')
-                            .map((n) => n[0])
-                            .join('')
-                            .toUpperCase()}
+                            ? stakeholder.displayName
+                                .split(' ')
+                                .map((n) => n[0])
+                                .join('')
+                                .toUpperCase()
+                            : "👤"}
                         </AvatarFallback>
                       </Avatar>
                       <div>

--- a/components/stakeholder-section.tsx
+++ b/components/stakeholder-section.tsx
@@ -132,7 +132,7 @@ export function StakeholderSection({
                                   .split(" ")
                                   .map((n) => n[0])
                                   .join("")
-                              : "?"}
+                              : "👤"}
                           </AvatarFallback>
                         </Avatar>
                         <div>

--- a/components/stakeholders/StakeholderListView.tsx
+++ b/components/stakeholders/StakeholderListView.tsx
@@ -103,10 +103,12 @@ export function StakeholderListView({
                   <AvatarImage src={stakeholder.photoURL} alt={stakeholder.displayName} />
                   <AvatarFallback>
                     {stakeholder.displayName
-                      .split(" ")
-                      .map((n) => n[0])
-                      .join("")
-                      .toUpperCase()}
+                      ? stakeholder.displayName
+                          .split(" ")
+                          .map((n) => n[0])
+                          .join("")
+                          .toUpperCase()
+                      : "👤"}
                   </AvatarFallback>
                 </Avatar>
                 <div className="flex flex-col">

--- a/components/stakeholders/TeamHierarchyTree.tsx
+++ b/components/stakeholders/TeamHierarchyTree.tsx
@@ -207,10 +207,12 @@ export function TeamHierarchyTree({
                   <AvatarImage src={stakeholder.photoURL} alt={stakeholder.displayName} />
                   <AvatarFallback>
                     {stakeholder.displayName
-                      .split(" ")
-                      .map((n) => n[0])
-                      .join("")
-                      .toUpperCase()}
+                      ? stakeholder.displayName
+                          .split(" ")
+                          .map((n) => n[0])
+                          .join("")
+                          .toUpperCase()
+                      : "👤"}
                   </AvatarFallback>
                 </Avatar>
                 <div className="flex flex-col flex-1">

--- a/lib/infrastructure/firestoreStakeholdersRepository.ts
+++ b/lib/infrastructure/firestoreStakeholdersRepository.ts
@@ -65,6 +65,7 @@ export class FirestoreStakeholdersRepository implements StakeholdersRepository {
     // Create new stakeholder
     const docRef = await addDoc(collection(db, this.collectionPath), {
       email: props.email,
+      displayName: props.displayName,
       photoURL: props.photoURL,
     });
 


### PR DESCRIPTION
fixes #10 

## Summary
- Fixed bug where stakeholders without photoURL don't appear in team hierarchy
- Fixed critical bug in stakeholder creation where displayName wasn't saved to Firestore
- Added null checks and user-friendly fallbacks in all stakeholder avatar components

## Test plan
- Verify stakeholders without photoURL appear correctly in team hierarchy
- Verify new stakeholders created through admin page have displayName saved to Firestore
- Verify stakeholder avatars display correctly with various combinations of missing data

🤖 Generated with [Claude Code](https://claude.ai/code)