### PR TITLE
feature:  Add was_blocked_by decision relationship

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,68 +1,82 @@
-'use client'
+"use client";
 
-import { useState, useEffect } from 'react'
-import { TeamHierarchyTree } from '@/components/TeamHierarchyTree'
-import { useAuth } from '@/hooks/useAuth'
-import { redirect, useSearchParams } from 'next/navigation'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { useOrganisation } from '@/components/organisation-switcher'
-import { Building2 } from 'lucide-react'
-import { useOrganisations } from '@/hooks/useOrganisations'
-import { StakeholderManagement } from '@/components/StakeholderManagement'
+import { useState, useEffect } from "react";
+import { TeamHierarchyTree } from "@/components/TeamHierarchyTree";
+import { useAuth } from "@/hooks/useAuth";
+import { redirect, useSearchParams } from "next/navigation";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useOrganisation } from "@/components/organisation-switcher";
+import { Building2 } from "lucide-react";
+import { useOrganisations } from "@/hooks/useOrganisations";
+import { StakeholderManagement } from "@/components/StakeholderManagement";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select"
+} from "@/components/ui/select";
 
 export default function AdminPage() {
-  const { user, loading: authLoading, isAdmin } = useAuth()
-  const { selectedOrganisation } = useOrganisation()
-  const { organisations, loading: orgsLoading, fetchAllOrganisations } = useOrganisations()
-  const [organisationId, setOrganisationId] = useState<string | null>(null)
-  const searchParams = useSearchParams()
-  const tabParam = searchParams.get('tab')
-  const [activeTab, setActiveTab] = useState<string>('team-hierarchy')
+  const { user, loading: authLoading, isAdmin } = useAuth();
+  const { selectedOrganisation } = useOrganisation();
+  const {
+    organisations,
+    loading: orgsLoading,
+    fetchAllOrganisations,
+  } = useOrganisations();
+  const [organisationId, setOrganisationId] = useState<string | null>(null);
+  const searchParams = useSearchParams();
+  const tabParam = searchParams?.get("tab") ?? "team-hierarchy";
+  const [activeTab, setActiveTab] = useState<string>("team-hierarchy");
 
   useEffect(() => {
     // Fetch all organizations for admin view
     if (isAdmin) {
-      fetchAllOrganisations().catch(error => {
-        console.error('Failed to fetch all organisations:', error)
-      })
+      fetchAllOrganisations().catch((error) => {
+        console.error("Failed to fetch all organisations:", error);
+      });
     }
-  }, [isAdmin, fetchAllOrganisations])
+  }, [isAdmin, fetchAllOrganisations]);
 
   useEffect(() => {
     if (selectedOrganisation) {
-      setOrganisationId(selectedOrganisation.id)
+      setOrganisationId(selectedOrganisation.id);
     }
-  }, [selectedOrganisation])
+  }, [selectedOrganisation]);
 
   // Set the active tab based on the URL parameter
   useEffect(() => {
     if (tabParam) {
-      setActiveTab(tabParam)
+      setActiveTab(tabParam);
     }
-  }, [tabParam])
+  }, [tabParam]);
 
   if (authLoading || orgsLoading) {
-    return <div className="flex items-center justify-center min-h-screen">Loading...</div>
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        Loading...
+      </div>
+    );
   }
 
   // If user is not logged in, redirect to login page
   if (!user) {
-    redirect('/login')
-    return null
+    redirect("/login");
+    return null;
   }
 
   // If user is not an admin, redirect to organization page
   if (!isAdmin) {
-    redirect('/organisation')
-    return null
+    redirect("/organisation");
+    return null;
   }
 
   return (
@@ -71,14 +85,17 @@ export default function AdminPage() {
         <h1 className="text-3xl font-bold">Admin Dashboard</h1>
         <div className="flex items-center gap-4">
           <Select
-            value={organisationId || ''}
+            value={organisationId || ""}
             onValueChange={(value) => setOrganisationId(value)}
           >
             <SelectTrigger className="w-[250px]">
               <SelectValue placeholder="Select organisation">
                 <div className="flex items-center gap-2">
                   <Building2 className="h-4 w-4" />
-                  <span>{organisations?.find(org => org.id === organisationId)?.name || "Select organisation"}</span>
+                  <span>
+                    {organisations?.find((org) => org.id === organisationId)
+                      ?.name || "Select organisation"}
+                  </span>
                 </div>
               </SelectValue>
             </SelectTrigger>
@@ -95,7 +112,7 @@ export default function AdminPage() {
           </Select>
         </div>
       </div>
-      
+
       {!organisationId ? (
         <Card>
           <CardContent className="flex items-center justify-center min-h-[200px] text-muted-foreground">
@@ -103,7 +120,12 @@ export default function AdminPage() {
           </CardContent>
         </Card>
       ) : (
-        <Tabs defaultValue={activeTab} value={activeTab} onValueChange={setActiveTab} className="w-full">
+        <Tabs
+          defaultValue={activeTab}
+          value={activeTab}
+          onValueChange={setActiveTab}
+          className="w-full"
+        >
           <TabsList className="mb-4">
             <TabsTrigger value="team-hierarchy">Teams</TabsTrigger>
             <TabsTrigger value="stakeholders">Stakeholders</TabsTrigger>
@@ -169,5 +191,5 @@ export default function AdminPage() {
         </Tabs>
       )}
     </div>
-  )
-} 
+  );
+}

--- a/app/organisation/[organisationId]/decision/[id]/view/page.tsx
+++ b/app/organisation/[organisationId]/decision/[id]/view/page.tsx
@@ -1,29 +1,35 @@
-'use client'
+"use client";
 
-import { useParams } from 'next/navigation'
-import { useDecision } from '@/hooks/useDecisions'
-import { useStakeholders } from '@/hooks/useStakeholders'
-import { DecisionSummary } from '@/components/decision-summary'
-import Link from 'next/link'
+import { useParams } from "next/navigation";
+import { useDecision } from "@/hooks/useDecisions";
+import { useStakeholders } from "@/hooks/useStakeholders";
+import { DecisionSummary } from "@/components/decision-summary";
+import Link from "next/link";
 
 function PublishedBanner() {
   return (
     <div className="bg-sky-100 p-4 rounded-md">
-      <p className="text-slate-700">This decision has been published and can no longer be edited</p>
+      <p className="text-slate-700">
+        This decision has been published and can no longer be edited
+      </p>
     </div>
-  )
+  );
 }
 
-function SupersededBanner({ supersedingDecisionId, supersedingDecisionTitle, organisationId }: { 
-  supersedingDecisionId: string
-  supersedingDecisionTitle: string
-  organisationId: string 
+function SupersededBanner({
+  supersedingDecisionId,
+  supersedingDecisionTitle,
+  organisationId,
+}: {
+  supersedingDecisionId: string;
+  supersedingDecisionTitle: string;
+  organisationId: string;
 }) {
   return (
     <div className="bg-amber-100 p-4 rounded-md">
       <p className="text-slate-700">
-        This decision has been superseded by{' '}
-        <Link 
+        This decision has been superseded by{" "}
+        <Link
           href={`/organisation/${organisationId}/decision/${supersedingDecisionId}/view`}
           className="text-amber-800 hover:text-amber-900 underline"
         >
@@ -31,42 +37,47 @@ function SupersededBanner({ supersedingDecisionId, supersedingDecisionTitle, org
         </Link>
       </p>
     </div>
-  )
+  );
 }
 
 export default function DecisionView() {
-  const params = useParams()
-  const { decision, loading } = useDecision(params.id as string, params.organisationId as string)
-  const { stakeholders } = useStakeholders()
+  const params = useParams();
+  const { stakeholders } = useStakeholders();
+  const { decision, loading } = useDecision(
+    (params?.id as string) || "",
+    (params?.organisationId as string) || "",
+  );
+
+  if (!params?.id || !params?.organisationId) {
+    return <div>Invalid parameters</div>;
+  }
 
   if (loading) {
-    return <div>Loading...</div>
+    return <div>Loading...</div>;
   }
 
   if (!decision) {
-    return <div>Decision not found</div>
+    return <div>Decision not found</div>;
   }
 
-  const supersededByRelationship = decision.getSupersededByRelationship()
+  const supersededByRelationship = decision.getSupersededByRelationship();
 
   return (
     <div className="space-y-8">
       <h1 className="text-2xl font-bold text-slate-900">{decision.title}</h1>
 
-      <DecisionSummary 
-        decision={decision}
-        stakeholders={stakeholders}
-      />
+      <DecisionSummary decision={decision} stakeholders={stakeholders} />
 
       {decision.isPublished() && <PublishedBanner />}
       {supersededByRelationship && (
-        <SupersededBanner 
+        <SupersededBanner
           supersedingDecisionId={supersededByRelationship.targetDecision.id}
-          supersedingDecisionTitle={supersededByRelationship.targetDecisionTitle}
+          supersedingDecisionTitle={
+            supersededByRelationship.targetDecisionTitle
+          }
           organisationId={params.organisationId as string}
         />
       )}
     </div>
-  )
+  );
 }
-

--- a/app/organisation/[organisationId]/decision/create/page.tsx
+++ b/app/organisation/[organisationId]/decision/create/page.tsx
@@ -1,28 +1,36 @@
-'use client'
+"use client";
 
-import { useEffect, useRef } from 'react'
-import { useRouter, useParams } from 'next/navigation'
-import { useOrganisationDecisions } from '@/hooks/useOrganisationDecisions'
-import { useAuth } from '@/hooks/useAuth'
+import { useEffect, useRef } from "react";
+import { useRouter, useParams } from "next/navigation";
+import { useOrganisationDecisions } from "@/hooks/useOrganisationDecisions";
+import { useAuth } from "@/hooks/useAuth";
 
 export default function DecisionPage() {
-  const router = useRouter()
-  const params = useParams()
-  const organisationId = params.organisationId as string
-  const { createDecision } = useOrganisationDecisions(organisationId)
-  const { user } = useAuth()
-  const hasCreatedDecision = useRef(false)
+  const router = useRouter();
+  const params = useParams();
+  const { user } = useAuth();
+  const organisationId = (params?.organisationId as string) || "";
+  const { createDecision } = useOrganisationDecisions(organisationId);
+  const hasCreatedDecision = useRef(false);
 
   useEffect(() => {
-    if (user) { // we need to wait until the logged in user is available
-      if (!hasCreatedDecision.current) { // we only want to run createDecision once
+    if (!params?.organisationId) return;
+
+    if (user) {
+      // we need to wait until the logged in user is available
+      if (!hasCreatedDecision.current) {
+        // we only want to run createDecision once
         hasCreatedDecision.current = true;
         createDecision().then((decision) => {
-          router.push(`${decision.id}/edit`)
-        })
+          router.push(`${decision.id}/edit`);
+        });
       }
     }
-  }, [user, createDecision, router])
+  }, [user, createDecision, router, params?.organisationId]);
 
-  return <div>Creating decision...</div>
-} 
+  if (!params?.organisationId) {
+    return <div>Invalid organisation ID</div>;
+  }
+
+  return <div>Creating decision...</div>;
+}

--- a/app/organisation/[organisationId]/page.tsx
+++ b/app/organisation/[organisationId]/page.tsx
@@ -1,16 +1,30 @@
-'use client'
+"use client";
 
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import { useOrganisation } from '@/components/organisation-switcher';
-import { useOrganisationDecisions } from '@/hooks/useOrganisationDecisions';
+import React, { useState, useEffect, useMemo, useCallback } from "react";
+import { useOrganisation } from "@/components/organisation-switcher";
+import { useOrganisationDecisions } from "@/hooks/useOrganisationDecisions";
 import { Button } from "@/components/ui/button";
-import { Pencil, Trash2, FileText, Users, Clock, Search, ArrowUpDown } from 'lucide-react';
-import Link from 'next/link';
-import { useParams } from 'next/navigation';
-import { WorkflowProgress } from '@/components/ui/workflow-progress';
-import { Decision, WorkflowNavigator } from '@/lib/domain/Decision';
+import {
+  Pencil,
+  Trash2,
+  FileText,
+  Users,
+  Clock,
+  Search,
+  ArrowUpDown,
+} from "lucide-react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { WorkflowProgress } from "@/components/ui/workflow-progress";
+import { Decision, WorkflowNavigator } from "@/lib/domain/Decision";
 import { Input } from "@/components/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 interface DecisionCardProps {
   decision: Decision;
@@ -18,19 +32,20 @@ interface DecisionCardProps {
   organisationId: string;
 }
 
-type SortOrder = 'newest' | 'oldest' | 'title-asc' | 'title-desc';
+type SortOrder = "newest" | "oldest" | "title-asc" | "title-desc";
 
 export default function OrganisationDecisionsList() {
   const params = useParams();
-  const organisationId = params.organisationId as string;
   const { selectedOrganisation } = useOrganisation();
-  const { decisions, loading, error, deleteDecision } = useOrganisationDecisions(organisationId);
-  
+  const organisationId = (params?.organisationId as string) || "";
+  const { decisions, loading, error, deleteDecision } =
+    useOrganisationDecisions(organisationId);
+
   // State for filters and search
-  const [searchQuery, setSearchQuery] = useState('');
-  const [statusFilter, setStatusFilter] = useState<string>('all');
-  const [sortOrder, setSortOrder] = useState<SortOrder>('newest');
-  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
+  const [searchQuery, setSearchQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [sortOrder, setSortOrder] = useState<SortOrder>("newest");
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
 
   // Create debounced search handler using useCallback
   const debouncedSearch = useCallback((value: string) => {
@@ -55,27 +70,33 @@ export default function OrganisationDecisionsList() {
     let filtered = decisions;
 
     // Apply status filter
-    if (statusFilter !== 'all') {
-      filtered = filtered.filter(d => d.status === statusFilter);
+    if (statusFilter !== "all") {
+      filtered = filtered.filter((d) => d.status === statusFilter);
     }
 
     // Apply search filter (if at least 3 characters or empty)
     if (debouncedSearchQuery.length >= 3) {
-      filtered = filtered.filter(d => 
-        d.title.toLowerCase().includes(debouncedSearchQuery.toLowerCase())
+      filtered = filtered.filter((d) =>
+        d.title.toLowerCase().includes(debouncedSearchQuery.toLowerCase()),
       );
     }
 
     // Apply sorting
     return [...filtered].sort((a, b) => {
       switch (sortOrder) {
-        case 'newest':
-          return (b.updatedAt || b.createdAt).getTime() - (a.updatedAt || a.createdAt).getTime();
-        case 'oldest':
-          return (a.updatedAt || a.createdAt).getTime() - (b.updatedAt || b.createdAt).getTime();
-        case 'title-asc':
+        case "newest":
+          return (
+            (b.updatedAt || b.createdAt).getTime() -
+            (a.updatedAt || a.createdAt).getTime()
+          );
+        case "oldest":
+          return (
+            (a.updatedAt || a.createdAt).getTime() -
+            (b.updatedAt || b.createdAt).getTime()
+          );
+        case "title-asc":
           return a.title.localeCompare(b.title);
-        case 'title-desc':
+        case "title-desc":
           return b.title.localeCompare(a.title);
         default:
           return 0;
@@ -89,10 +110,10 @@ export default function OrganisationDecisionsList() {
       in_progress: [] as Decision[],
       blocked: [] as Decision[],
       published: [] as Decision[],
-      superseded: [] as Decision[]
+      superseded: [] as Decision[],
     };
 
-    filteredAndSortedDecisions.forEach(decision => {
+    filteredAndSortedDecisions.forEach((decision) => {
       if (decision.status in groups) {
         groups[decision.status as keyof typeof groups].push(decision);
       }
@@ -101,20 +122,33 @@ export default function OrganisationDecisionsList() {
     return groups;
   }, [filteredAndSortedDecisions]);
 
+  if (!params?.organisationId) {
+    return <div>Invalid organisation ID</div>;
+  }
+
   if (loading) return <div className="p-6">Loading decisions...</div>;
-  if (error) return <div className="p-6 text-red-500">Error loading decisions: {error.message}</div>;
+  if (error)
+    return (
+      <div className="p-6 text-red-500">
+        Error loading decisions: {error.message}
+      </div>
+    );
   if (!selectedOrganisation) return <p>...</p>;
 
   const handleDelete = async (decisionId: string) => {
     try {
       await deleteDecision(decisionId);
-      console.log('Decision deleted:', decisionId);
+      console.log("Decision deleted:", decisionId);
     } catch (error) {
-      console.error('Error deleting decision:', error);
+      console.error("Error deleting decision:", error);
     }
   };
 
-  const DecisionCard = ({ decision, showEditButton = true, organisationId }: DecisionCardProps) => {
+  const DecisionCard = ({
+    decision,
+    showEditButton = true,
+    organisationId,
+  }: DecisionCardProps) => {
     return (
       <div
         key={decision.id}
@@ -134,7 +168,11 @@ export default function OrganisationDecisionsList() {
           )}
           <div className="flex items-center gap-4 mt-2 text-sm text-gray-500">
             <div className="flex items-center gap-1">
-              <WorkflowProgress currentStep={WorkflowNavigator.getStepIndex(decision.currentStep) + 1} />
+              <WorkflowProgress
+                currentStep={
+                  WorkflowNavigator.getStepIndex(decision.currentStep) + 1
+                }
+              />
             </div>
             <div className="flex items-center gap-1">
               <Users className="h-4 w-4" />
@@ -142,20 +180,28 @@ export default function OrganisationDecisionsList() {
             </div>
             <div className="flex items-center gap-1">
               <Clock className="h-4 w-4" />
-              <span>Updated {decision.updatedAt?.toLocaleDateString() || decision.createdAt.toLocaleDateString()}</span>
+              <span>
+                Updated{" "}
+                {decision.updatedAt?.toLocaleDateString() ||
+                  decision.createdAt.toLocaleDateString()}
+              </span>
             </div>
           </div>
         </div>
         <div className="flex space-x-2">
           {showEditButton ? (
             <Button variant="ghost" size="icon" title="Edit decision" asChild>
-              <Link href={`/organisation/${organisationId}/decision/${decision.id}/edit`}>
+              <Link
+                href={`/organisation/${organisationId}/decision/${decision.id}/edit`}
+              >
                 <Pencil className="h-4 w-4" />
               </Link>
             </Button>
           ) : (
             <Button variant="ghost" size="icon" title="View decision" asChild>
-              <Link href={`/organisation/${organisationId}/decision/${decision.id}/view`}>
+              <Link
+                href={`/organisation/${organisationId}/decision/${decision.id}/view`}
+              >
                 <FileText className="h-4 w-4" />
               </Link>
             </Button>
@@ -173,9 +219,15 @@ export default function OrganisationDecisionsList() {
     );
   };
 
-  const DecisionGroup = ({ title, decisions }: { title: string, decisions: Decision[] }) => {
-    if (statusFilter !== 'all' && !decisions.length) return null;
-    
+  const DecisionGroup = ({
+    title,
+    decisions,
+  }: {
+    title: string;
+    decisions: Decision[];
+  }) => {
+    if (statusFilter !== "all" && !decisions.length) return null;
+
     return (
       <div>
         <h2 className="text-lg font-medium mb-4">{title}</h2>
@@ -184,11 +236,14 @@ export default function OrganisationDecisionsList() {
             <DecisionCard
               key={decision.id}
               decision={decision}
-              showEditButton={decision.status === 'in_progress' || decision.status === 'blocked'}
+              showEditButton={
+                decision.status === "in_progress" ||
+                decision.status === "blocked"
+              }
               organisationId={organisationId}
             />
           ))}
-          {statusFilter === 'all' && !decisions.length && (
+          {statusFilter === "all" && !decisions.length && (
             <p className="text-gray-500">No {title.toLowerCase()} decisions</p>
           )}
         </div>
@@ -199,7 +254,10 @@ export default function OrganisationDecisionsList() {
   return (
     <div className="container mx-auto py-6">
       <h1 className="text-3xl font-bold mb-6">
-        <span className="text-primary bg-gray-100 rounded-md px-2 py-1">{selectedOrganisation.name}</span>&apos;s Decisions
+        <span className="text-primary bg-gray-100 rounded-md px-2 py-1">
+          {selectedOrganisation.name}
+        </span>
+        &apos;s Decisions
       </h1>
 
       {/* Filters and Search Bar */}
@@ -225,7 +283,10 @@ export default function OrganisationDecisionsList() {
             <SelectItem value="published">Published</SelectItem>
           </SelectContent>
         </Select>
-        <Select value={sortOrder} onValueChange={(value) => setSortOrder(value as SortOrder)}>
+        <Select
+          value={sortOrder}
+          onValueChange={(value) => setSortOrder(value as SortOrder)}
+        >
           <SelectTrigger className="w-[180px]">
             <SelectValue placeholder="Sort by" />
           </SelectTrigger>
@@ -265,14 +326,25 @@ export default function OrganisationDecisionsList() {
           </div>
         ) : (
           <>
-            <DecisionGroup title="In Progress" decisions={groupedDecisions.in_progress} />
-            <DecisionGroup title="Blocked" decisions={groupedDecisions.blocked} />
-            <DecisionGroup title="Published" decisions={groupedDecisions.published} />
-            <DecisionGroup title="Superseded" decisions={groupedDecisions.superseded} />
+            <DecisionGroup
+              title="In Progress"
+              decisions={groupedDecisions.in_progress}
+            />
+            <DecisionGroup
+              title="Blocked"
+              decisions={groupedDecisions.blocked}
+            />
+            <DecisionGroup
+              title="Published"
+              decisions={groupedDecisions.published}
+            />
+            <DecisionGroup
+              title="Superseded"
+              decisions={groupedDecisions.superseded}
+            />
           </>
         )}
       </div>
     </div>
   );
 }
-

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -1,16 +1,15 @@
-"use client"
+"use client";
 
-import * as React from "react"
+import * as React from "react";
+import { Sparkles, ListTodo, Users } from "lucide-react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+
+import { NavUser } from "./nav-user";
 import {
-  Sparkles,
-  ListTodo,
-  Users,
-} from "lucide-react"
-import { useParams } from 'next/navigation'
-import Link from 'next/link'
-
-import { NavUser } from "./nav-user"
-import { OrganisationSwitcher, useOrganisation } from "@/components/organisation-switcher"
+  OrganisationSwitcher,
+  useOrganisation,
+} from "@/components/organisation-switcher";
 import {
   Sidebar,
   SidebarContent,
@@ -23,23 +22,25 @@ import {
   SidebarMenuItem,
   SidebarMenuButton,
   useSidebar,
-} from "@/components/ui/sidebar"
-import { useAuth } from "@/hooks/useAuth"
+} from "@/components/ui/sidebar";
+import { useAuth } from "@/hooks/useAuth";
 
 export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
   const { user, isAdmin } = useAuth();
   const { selectedOrganisation } = useOrganisation();
   const params = useParams();
-  const organisationId = params.organisationId as string;
+  const organisationId = (params?.organisationId as string) || "";
   const { state } = useSidebar();
   const isCollapsed = state === "collapsed";
 
   // Create user data object from authenticated user
-  const userData = user ? {
-    name: user.displayName || 'Anonymous',
-    email: user.email || '',
-    avatar: user.photoURL || '',
-  } : null;
+  const userData = user
+    ? {
+        name: user.displayName || "Anonymous",
+        email: user.email || "",
+        avatar: user.photoURL || "",
+      }
+    : null;
 
   if (!userData) return null;
 
@@ -57,7 +58,10 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
               <SidebarMenu>
                 <SidebarMenuItem>
                   <SidebarMenuButton tooltip="Decisions" asChild>
-                    <Link href={`/organisation/${organisationId}`} className={`flex items-center gap-2 px-3 py-2 rounded-md hover:bg-sidebar-accent transition-colors ${isCollapsed ? 'justify-center' : 'w-full'}`}>
+                    <Link
+                      href={`/organisation/${organisationId}`}
+                      className={`flex items-center gap-2 px-3 py-2 rounded-md hover:bg-sidebar-accent transition-colors ${isCollapsed ? "justify-center" : "w-full"}`}
+                    >
                       <ListTodo className="h-4 w-4" />
                       {!isCollapsed && <span>Decision list</span>}
                     </Link>
@@ -67,7 +71,10 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
               <SidebarMenu>
                 <SidebarMenuItem>
                   <SidebarMenuButton tooltip="New decision" asChild>
-                    <Link href={`/organisation/${organisationId}/decision/create`} className={`flex items-center gap-2 px-3 py-2 rounded-md bg-blue-500 text-white hover:bg-blue-700 transition-colors ${isCollapsed ? 'justify-center' : 'w-fit'}`}>
+                    <Link
+                      href={`/organisation/${organisationId}/decision/create`}
+                      className={`flex items-center gap-2 px-3 py-2 rounded-md bg-blue-500 text-white hover:bg-blue-700 transition-colors ${isCollapsed ? "justify-center" : "w-fit"}`}
+                    >
                       <Sparkles className="h-4 w-4" />
                       {!isCollapsed && <span>New decision</span>}
                     </Link>
@@ -83,7 +90,10 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
                 <SidebarMenu>
                   <SidebarMenuItem>
                     <SidebarMenuButton tooltip="Teams" asChild>
-                      <Link href="/admin?tab=team-hierarchy" className={`flex items-center gap-2 px-3 py-2 rounded-md hover:bg-sidebar-accent transition-colors ${isCollapsed ? 'justify-center' : 'w-full'}`}>
+                      <Link
+                        href="/admin?tab=team-hierarchy"
+                        className={`flex items-center gap-2 px-3 py-2 rounded-md hover:bg-sidebar-accent transition-colors ${isCollapsed ? "justify-center" : "w-full"}`}
+                      >
                         <Users className="h-4 w-4" />
                         {!isCollapsed && <span>Teams</span>}
                       </Link>
@@ -100,6 +110,5 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
       </SidebarFooter>
       <SidebarRail />
     </Sidebar>
-  )
+  );
 }
-

--- a/components/decision-relationships-list.tsx
+++ b/components/decision-relationships-list.tsx
@@ -1,36 +1,54 @@
-import { Decision, DecisionRelationshipType } from '@/lib/domain/Decision'
-import { Button } from '@/components/ui/button'
-import { AddDecisionRelationshipDialog } from '@/components/add-decision-relationship-dialog'
-import { useDecisionRelationships, SelectedDecisionDetails } from '@/hooks/useDecisionRelationships'
-import { Plus, X } from 'lucide-react'
-import Link from 'next/link'
+import { Decision, DecisionRelationshipType } from "@/lib/domain/Decision";
+import { Button } from "@/components/ui/button";
+import { AddDecisionRelationshipDialog } from "@/components/add-decision-relationship-dialog";
+import {
+  useDecisionRelationships,
+  SelectedDecisionDetails,
+} from "@/hooks/useDecisionRelationships";
+import { Plus, X } from "lucide-react";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
 
 interface DecisionRelationshipItemProps {
   targetDecision: Decision;
   type: DecisionRelationshipType;
-  onRemove: (type: DecisionRelationshipType, targetDecision: Decision) => Promise<void>;
+  onRemove: (
+    type: DecisionRelationshipType,
+    targetDecision: Decision,
+  ) => Promise<void>;
 }
 
-function DecisionRelationshipItem({ targetDecision, type, onRemove }: DecisionRelationshipItemProps) {
+function DecisionRelationshipItem({
+  targetDecision,
+  type,
+  onRemove,
+}: DecisionRelationshipItemProps) {
+  const isWasBlockedBy = type === "was_blocked_by";
+
   return (
     <div className="flex items-center justify-between p-2 bg-muted rounded-md group">
       <div>
         <Link
           href={`/organisation/${targetDecision.organisationId}/decision/${targetDecision.id}/edit`}
-          className="font-medium hover:underline"
+          className={cn(
+            "font-medium hover:underline",
+            isWasBlockedBy && "line-through text-muted-foreground",
+          )}
         >
           {targetDecision.title}
         </Link>
       </div>
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={() => onRemove(type, targetDecision)}
-        className="opacity-0 group-hover:opacity-100 transition-opacity"
-        title="Remove relationship"
-      >
-        <X className="h-4 w-4" />
-      </Button>
+      {!isWasBlockedBy && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onRemove(type, targetDecision)}
+          className="opacity-0 group-hover:opacity-100 transition-opacity"
+          title="Remove relationship"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      )}
     </div>
   );
 }
@@ -46,26 +64,38 @@ export function DecisionRelationshipsList({
   relationshipType,
   title,
 }: DecisionRelationshipsListProps) {
-  const { addRelationship, removeRelationship } = useDecisionRelationships(fromDecision);
+  const { addRelationship, removeRelationship } =
+    useDecisionRelationships(fromDecision);
 
   const getRelationshipsForType = (type: DecisionRelationshipType) => {
-    const relationships = fromDecision.getRelationshipsByType(type);
-    return relationships.map(relationship => ({
+    let relationships = [];
+
+    // If we're showing blocked_by relationships, also include was_blocked_by
+    if (type === "blocked_by") {
+      relationships = [
+        ...fromDecision.getRelationshipsByType("blocked_by"),
+        ...fromDecision.getRelationshipsByType("was_blocked_by"),
+      ];
+    } else {
+      relationships = fromDecision.getRelationshipsByType(type);
+    }
+
+    return relationships.map((relationship) => ({
       targetDecision: Decision.create({
         id: relationship.targetDecision.id,
         title: relationship.targetDecisionTitle,
-        description: '',
-        cost: 'low',
+        description: "",
+        cost: "low",
         createdAt: new Date(),
-        reversibility: 'hat',
+        reversibility: "hat",
         stakeholders: [],
-        driverStakeholderId: '',
+        driverStakeholderId: "",
         organisationId: fromDecision.organisationId,
         teamIds: [],
         projectIds: [],
-        supportingMaterials: []
+        supportingMaterials: [],
       }),
-      type: relationship.type
+      type: relationship.type,
     }));
   };
 
@@ -73,20 +103,25 @@ export function DecisionRelationshipsList({
     await addRelationship(details, relationshipType);
   };
 
-  const handleRemove = async (type: DecisionRelationshipType, targetDecision: Decision) => {
+  const handleRemove = async (
+    type: DecisionRelationshipType,
+    targetDecision: Decision,
+  ) => {
     await removeRelationship(type, targetDecision);
   };
 
-  const getRelationshipDescriptionForAddDialog = (type: DecisionRelationshipType): string => {
+  const getRelationshipDescriptionForAddDialog = (
+    type: DecisionRelationshipType,
+  ): string => {
     switch (type) {
-      case 'blocked_by':
-        return 'Select a decision that blocks this decision';
-      case 'blocks':
-        return 'Select a decision that this decision blocks';
-      case 'supersedes':
-        return 'Select a decision that this decision supersedes';
-      case 'superseded_by':
-        return 'Select a decision that supersedes this decision';
+      case "blocked_by":
+        return "Select a decision that blocks this decision";
+      case "blocks":
+        return "Select a decision that this decision blocks";
+      case "supersedes":
+        return "Select a decision that this decision supersedes";
+      case "superseded_by":
+        return "Select a decision that supersedes this decision";
     }
   };
 
@@ -99,7 +134,9 @@ export function DecisionRelationshipsList({
         <h3 className="text-base text-muted-foreground font-normal">{title}</h3>
         <AddDecisionRelationshipDialog
           onAdd={handleAdd}
-          relationshipDescription={getRelationshipDescriptionForAddDialog(relationshipType)}
+          relationshipDescription={getRelationshipDescriptionForAddDialog(
+            relationshipType,
+          )}
           organisationId={fromDecision.organisationId}
         >
           <Button variant="ghost" size="icon" className="h-6 w-6 ml-1 -mt-0.5">

--- a/components/decision-relationships-list.tsx
+++ b/components/decision-relationships-list.tsx
@@ -122,6 +122,12 @@ export function DecisionRelationshipsList({
         return "Select a decision that this decision supersedes";
       case "superseded_by":
         return "Select a decision that supersedes this decision";
+      case "did_block":
+        return "Select a decision that this decision blocked";
+      case "was_blocked_by":
+        return "Select a decision that blocked this decision";
+      default:
+        return `Select a decision to create a ${type} relationship`;
     }
   };
 

--- a/hooks/useDecisions.ts
+++ b/hooks/useDecisions.ts
@@ -23,7 +23,10 @@ export function useDecision(decisionId: string, organisationId: string) {
       try {
         // First get the decision by ID to ensure we have a valid Decision object
         const scope: DecisionScope = { organisationId };
-        const fetchedDecision = await decisionsRepository.getById(decisionId, scope);
+        const fetchedDecision = await decisionsRepository.getById(
+          decisionId,
+          scope,
+        );
         // Then subscribe to updates
         unsubscribe = decisionsRepository.subscribeToOne(
           fetchedDecision,
@@ -35,13 +38,13 @@ export function useDecision(decisionId: string, organisationId: string) {
           (error: Error) => {
             setError(error);
             setLoading(false);
-          }
+          },
         );
       } catch (err) {
         setError(err as Error);
         setLoading(false);
       }
-    }
+    };
 
     fetchDecision();
 
@@ -55,9 +58,7 @@ export function useDecision(decisionId: string, organisationId: string) {
   const updateDecisionTitle = async (title: string) => {
     try {
       if (!decision) return;
-      await decisionsRepository.update(
-        decision.with({ title }),
-      );
+      await decisionsRepository.update(decision.with({ title }));
     } catch (error) {
       setError(error as Error);
       throw error;
@@ -67,9 +68,7 @@ export function useDecision(decisionId: string, organisationId: string) {
   const updateDecisionDescription = async (description: string) => {
     try {
       if (!decision) return;
-      await decisionsRepository.update(
-        decision.with({ description }),
-      );
+      await decisionsRepository.update(decision.with({ description }));
     } catch (error) {
       setError(error as Error);
       throw error;
@@ -79,9 +78,7 @@ export function useDecision(decisionId: string, organisationId: string) {
   const updateDecisionCost = async (cost: Cost) => {
     try {
       if (!decision) return;
-      await decisionsRepository.update(
-        decision.with({ cost }),
-      );
+      await decisionsRepository.update(decision.with({ cost }));
     } catch (error) {
       setError(error as Error);
       throw error;
@@ -91,9 +88,7 @@ export function useDecision(decisionId: string, organisationId: string) {
   const updateDecisionReversibility = async (reversibility: Reversibility) => {
     try {
       if (!decision) return;
-      await decisionsRepository.update(
-        decision.with({ reversibility }),
-      );
+      await decisionsRepository.update(decision.with({ reversibility }));
     } catch (error) {
       setError(error as Error);
       throw error;
@@ -112,12 +107,12 @@ export function useDecision(decisionId: string, organisationId: string) {
     }
   };
 
-  const updateStakeholders = async (stakeholders: DecisionStakeholderRole[]) => {
+  const updateStakeholders = async (
+    stakeholders: DecisionStakeholderRole[],
+  ) => {
     try {
       if (!decision) return;
-      await decisionsRepository.update(
-        decision.with({ stakeholders }),
-      );
+      await decisionsRepository.update(decision.with({ stakeholders }));
     } catch (error) {
       setError(error as Error);
       throw error;
@@ -126,7 +121,7 @@ export function useDecision(decisionId: string, organisationId: string) {
 
   const addStakeholder = async (
     stakeholderId: string,
-    role: DecisionStakeholderRole["role"] = "informed"
+    role: DecisionStakeholderRole["role"] = "informed",
   ) => {
     try {
       if (!decision) return;
@@ -166,9 +161,7 @@ export function useDecision(decisionId: string, organisationId: string) {
   const updateDecisionContent = async (content: string) => {
     try {
       if (!decision) return;
-      await decisionsRepository.update(
-        decision.with({ decision: content }),
-      );
+      await decisionsRepository.update(decision.with({ decision: content }));
     } catch (error) {
       setError(error as Error);
       throw error;
@@ -203,7 +196,9 @@ export function useDecision(decisionId: string, organisationId: string) {
   const removeSupportingMaterial = async (materialUrl: string) => {
     try {
       if (!decision) return;
-      const newMaterials = decision.supportingMaterials.filter(m => m.url !== materialUrl);
+      const newMaterials = decision.supportingMaterials.filter(
+        (m) => m.url !== materialUrl,
+      );
       await decisionsRepository.update(
         decision.with({ supportingMaterials: newMaterials }),
       );
@@ -216,9 +211,9 @@ export function useDecision(decisionId: string, organisationId: string) {
   const publishDecision = async () => {
     try {
       if (!decision) return;
-      await decisionsRepository.update(
-        decision.publish()
-      );
+      await decisionsRepository.publishDecision(decision.id, {
+        organisationId,
+      });
     } catch (error) {
       setError(error as Error);
       throw error;
@@ -233,9 +228,7 @@ export function useDecision(decisionId: string, organisationId: string) {
   const updateDecisionNotes = async (decisionNotes: string) => {
     try {
       if (!decision) return;
-      await decisionsRepository.update(
-        decision.with({ decisionNotes }),
-      );
+      await decisionsRepository.update(decision.with({ decisionNotes }));
     } catch (error) {
       setError(error as Error);
       throw error;

--- a/lib/domain/__tests__/Decision.test.ts
+++ b/lib/domain/__tests__/Decision.test.ts
@@ -10,8 +10,6 @@ describe('Decision Domain Model', () => {
     description: 'Test Description',
     cost: 'low',
     createdAt: new Date(),
-    criteria: [],
-    options: [],
     reversibility: 'hat',
     stakeholders: [],
     driverStakeholderId: 'driver-1',

--- a/lib/domain/__tests__/DecisionPublishing.test.ts
+++ b/lib/domain/__tests__/DecisionPublishing.test.ts
@@ -1,108 +1,250 @@
-import { describe, it, expect } from 'vitest'
-import { Decision, DecisionProps } from '@/lib/domain/Decision'
-import { DecisionStateError } from '@/lib/domain/DecisionError'
+import { describe, it, expect } from "vitest";
+import { Decision, DecisionProps } from "@/lib/domain/Decision";
+import { DecisionStateError } from "@/lib/domain/DecisionError";
 
-describe('Decision Publishing', () => {
+describe("Decision Publishing", () => {
   const defaultProps: DecisionProps = {
-    id: 'test-id',
-    title: 'Test Decision',
-    description: 'Test Description',
-    cost: 'low',
+    id: "test-id",
+    title: "Test Decision",
+    description: "Test Description",
+    cost: "low",
     createdAt: new Date(),
-    criteria: ['test-criteria'],
-    options: ['option-a', 'option-b'],
-    reversibility: 'hat',
-    stakeholders: [
-      { stakeholder_id: 'decider-1', role: 'decider' }
-    ],
-    driverStakeholderId: 'decider-1',
-    organisationId: 'org-1',
-    teamIds: ['team-1'],
-    projectIds: ['project-1'],
+    reversibility: "hat",
+    stakeholders: [{ stakeholder_id: "decider-1", role: "decider" }],
+    driverStakeholderId: "decider-1",
+    organisationId: "org-1",
+    teamIds: ["team-1"],
+    projectIds: ["project-1"],
     supportingMaterials: [],
-    relationships: {}
-  }
+    relationships: {},
+  };
 
-  describe('publish', () => {
-    it('should successfully publish a valid decision', () => {
+  describe("publish", () => {
+    it("should successfully publish a valid decision", () => {
       const decision = Decision.create({
         ...defaultProps,
-        decision: 'option-a',
-        decisionMethod: 'consent'
-      })
+        decision: "option-a",
+        decisionMethod: "consent",
+      });
 
-      const publishedDecision = decision.publish()
-      
-      expect(publishedDecision.status).toBe('published')
-      expect(publishedDecision.publishDate).toBeDefined()
-      expect(publishedDecision.currentStep.key).toBe('publish')
-    })
+      const publishedDecision = decision.publish();
 
-    it('should set publishDate to current timestamp when publishing', () => {
-      const now = new Date()
+      expect(publishedDecision.status).toBe("published");
+      expect(publishedDecision.publishDate).toBeDefined();
+      expect(publishedDecision.currentStep.key).toBe("publish");
+    });
+
+    it("should set publishDate to current timestamp when publishing", () => {
+      const now = new Date();
       const decision = Decision.create({
         ...defaultProps,
-        decision: 'option-a',
-        decisionMethod: 'consent'
-      })
+        decision: "option-a",
+        decisionMethod: "consent",
+      });
 
-      const publishedDecision = decision.publish()
-      
-      expect(publishedDecision.publishDate).toBeInstanceOf(Date)
-      expect(publishedDecision.publishDate!.getTime()).toBeGreaterThanOrEqual(now.getTime())
-      expect(publishedDecision.publishDate!.getTime()).toBeLessThanOrEqual(new Date().getTime())
-    })
+      const publishedDecision = decision.publish();
 
-    it('should throw error when publishing a decision without a chosen option', () => {
+      expect(publishedDecision.publishDate).toBeInstanceOf(Date);
+      expect(publishedDecision.publishDate!.getTime()).toBeGreaterThanOrEqual(
+        now.getTime(),
+      );
+      expect(publishedDecision.publishDate!.getTime()).toBeLessThanOrEqual(
+        new Date().getTime(),
+      );
+    });
+
+    it("should throw error when publishing a decision without a chosen option", () => {
       const decision = Decision.create({
         ...defaultProps,
-        decisionMethod: 'consent'
-      })
+        decisionMethod: "consent",
+      });
 
-      expect(() => decision.publish()).toThrow(DecisionStateError)
-    })
+      expect(() => decision.publish()).toThrow(DecisionStateError);
+    });
 
-    it('should throw error when publishing an already published decision', () => {
+    it("should throw error when publishing an already published decision", () => {
       const decision = Decision.create({
         ...defaultProps,
-        decision: 'option-a',
-        decisionMethod: 'consent',
-        publishDate: new Date()
-      })
+        decision: "option-a",
+        decisionMethod: "consent",
+        publishDate: new Date(),
+      });
 
-      expect(() => decision.publish()).toThrow(DecisionStateError)
-    })
+      expect(() => decision.publish()).toThrow(DecisionStateError);
+    });
 
-    it('should throw error when publishing a blocked decision', () => {
+    it("should throw error when publishing a blocked decision", () => {
       const blockingDecision = Decision.create({
         ...defaultProps,
-        id: 'blocking-decision',
-        title: 'Blocking Decision'
-      })
+        id: "blocking-decision",
+        title: "Blocking Decision",
+      });
 
       const decision = Decision.create({
         ...defaultProps,
-        decision: 'option-a',
-        decisionMethod: 'consent'
-      }).setRelationship('blocked_by', blockingDecision)
+        decision: "option-a",
+        decisionMethod: "consent",
+      }).setRelationship("blocked_by", blockingDecision);
 
-      expect(() => decision.publish()).toThrow(DecisionStateError)
-    })
+      expect(() => decision.publish()).toThrow(DecisionStateError);
+    });
 
-    it('should throw error when publishing a superseded decision', () => {
+    it("should throw error when publishing a superseded decision", () => {
       const supersedingDecision = Decision.create({
         ...defaultProps,
-        id: 'superseding-decision',
-        title: 'Superseding Decision'
-      })
+        id: "superseding-decision",
+        title: "Superseding Decision",
+      });
 
       const decision = Decision.create({
         ...defaultProps,
-        decision: 'option-a',
-        decisionMethod: 'consent'
-      }).setRelationship('superseded_by', supersedingDecision)
+        decision: "option-a",
+        decisionMethod: "consent",
+      }).setRelationship("superseded_by", supersedingDecision);
 
-      expect(() => decision.publish()).toThrow(DecisionStateError)
-    })
-  })
-}) 
+      expect(() => decision.publish()).toThrow(DecisionStateError);
+    });
+  });
+
+  describe("relationship transitions on publish", () => {
+    it("should transform blocks relationships to did_block when a decision is published", () => {
+      // Create the decisions
+      const decisionA = Decision.create({
+        ...defaultProps,
+        id: "decision-a",
+        title: "Decision A",
+        decision: "option-a",
+        decisionMethod: "consent",
+      });
+
+      const decisionB = Decision.create({
+        ...defaultProps,
+        id: "decision-b",
+        title: "Decision B",
+      });
+
+      // Set up the blocking relationship: A blocks B
+      const aBlocksB = decisionA.setRelationship("blocks", decisionB);
+      const bBlockedByA = decisionB.setRelationship("blocked_by", decisionA);
+
+      // Verify initial relationship
+      expect(aBlocksB.getRelationshipsByType("blocks")).toHaveLength(1);
+      expect(bBlockedByA.getRelationshipsByType("blocked_by")).toHaveLength(1);
+
+      // Publish decision A
+      const publishedA = aBlocksB.publish();
+
+      // Check that the relationship type has changed
+      expect(publishedA.getRelationshipsByType("blocks")).toHaveLength(0);
+      expect(publishedA.getRelationshipsByType("did_block")).toHaveLength(1);
+
+      // Verify the content of the relationship
+      const didBlockRelationships =
+        publishedA.getRelationshipsByType("did_block");
+      expect(didBlockRelationships[0].targetDecision.id).toBe("decision-b");
+      expect(didBlockRelationships[0].targetDecisionTitle).toBe("Decision B");
+    });
+
+    it("should transform blocked_by relationships to was_blocked_by when the blocking decision is published", () => {
+      // Create the decisions
+      const decisionA = Decision.create({
+        ...defaultProps,
+        id: "decision-a",
+        title: "Decision A",
+        decision: "option-a",
+        decisionMethod: "consent",
+      });
+
+      const decisionB = Decision.create({
+        ...defaultProps,
+        id: "decision-b",
+        title: "Decision B",
+      });
+
+      // Set up the blocking relationship: A blocks B
+      const aBlocksB = decisionA.setRelationship("blocks", decisionB);
+      const bBlockedByA = decisionB.setRelationship("blocked_by", decisionA);
+
+      // Publish decision A - this should update its relationship to did_block
+      const publishedA = aBlocksB.publish();
+      expect(publishedA.getRelationshipsByType("did_block")).toHaveLength(1);
+
+      // After A is published, B should have relationship updated from blocked_by to was_blocked_by
+      // In a real application, this would be done by repository logic
+      // Here we manually update the relationship to simulate repository logic
+      const updatedB = bBlockedByA.with({
+        relationships: {
+          ...bBlockedByA.relationships,
+          ["blocked_by_" + decisionA.id]: {
+            targetDecision:
+              bBlockedByA.relationships!["blocked_by_" + decisionA.id]
+                .targetDecision,
+            targetDecisionTitle:
+              bBlockedByA.relationships!["blocked_by_" + decisionA.id]
+                .targetDecisionTitle,
+            type: "was_blocked_by",
+          },
+        },
+      });
+
+      // Check the updated relationships
+      expect(updatedB.getRelationshipsByType("blocked_by")).toHaveLength(0);
+      expect(updatedB.getRelationshipsByType("was_blocked_by")).toHaveLength(1);
+
+      // Verify that B is no longer blocked
+      expect(updatedB.isBlocked()).toBe(false);
+    });
+
+    it("should allow publishing a decision that was previously blocked after the blocking decision is published", () => {
+      // Create the decisions
+      const decisionA = Decision.create({
+        ...defaultProps,
+        id: "decision-a",
+        title: "Decision A",
+        decision: "option-a",
+        decisionMethod: "consent",
+      });
+
+      const decisionB = Decision.create({
+        ...defaultProps,
+        id: "decision-b",
+        title: "Decision B",
+        decision: "option-b",
+        decisionMethod: "consent",
+      });
+
+      // Set up the blocking relationship: A blocks B
+      const aBlocksB = decisionA.setRelationship("blocks", decisionB);
+      const bBlockedByA = decisionB.setRelationship("blocked_by", decisionA);
+
+      // B is blocked and should not be publishable
+      expect(() => bBlockedByA.publish()).toThrow(DecisionStateError);
+
+      // Publish decision A - this should update its relationship to did_block
+      const publishedA = aBlocksB.publish();
+      expect(publishedA.getRelationshipsByType("did_block")).toHaveLength(1);
+
+      // After A is published, B should have relationship updated from blocked_by to was_blocked_by
+      // In a real application, this would be done by repository logic
+      // Here we manually update the relationship to simulate repository logic
+      const updatedB = bBlockedByA.with({
+        relationships: {
+          ...bBlockedByA.relationships,
+          ["blocked_by_" + decisionA.id]: {
+            targetDecision:
+              bBlockedByA.relationships!["blocked_by_" + decisionA.id]
+                .targetDecision,
+            targetDecisionTitle:
+              bBlockedByA.relationships!["blocked_by_" + decisionA.id]
+                .targetDecisionTitle,
+            type: "was_blocked_by",
+          },
+        },
+      });
+
+      // B should now be publishable
+      const publishedB = updatedB.publish();
+      expect(publishedB.status).toBe("published");
+    });
+  });
+});

--- a/lib/infrastructure/__tests__/firestoreDecisionsRepository.integration.test.ts
+++ b/lib/infrastructure/__tests__/firestoreDecisionsRepository.integration.test.ts
@@ -1,44 +1,56 @@
-import { describe, it, expect, afterAll, beforeAll, vi } from 'vitest'
-import { FirestoreDecisionsRepository } from '@/lib/infrastructure/firestoreDecisionsRepository'
-import { Decision, DecisionRelationship } from '@/lib/domain/Decision'
-import { BASE_TEST_SCOPE, signInTestUser } from './helpers/firebaseTestHelper'
-import { Project } from '@/lib/domain/Project'
-import { FirestoreProjectDecisionsRepository } from '../firestoreProjectDecisionsRepository'
+import { describe, it, expect, afterAll, beforeAll, vi } from "vitest";
+import { FirestoreDecisionsRepository } from "@/lib/infrastructure/firestoreDecisionsRepository";
+import { Decision, DecisionRelationship } from "@/lib/domain/Decision";
+import { BASE_TEST_SCOPE, signInTestUser } from "./helpers/firebaseTestHelper";
+import { Project } from "@/lib/domain/Project";
+import { FirestoreProjectDecisionsRepository } from "../firestoreProjectDecisionsRepository";
 
-describe('FirestoreDecisionsRepository Integration Tests', () => {
+describe("FirestoreDecisionsRepository Integration Tests", () => {
   const repository = new FirestoreDecisionsRepository();
   const projectRepository = new FirestoreProjectDecisionsRepository();
   const decisionsToCleanUp: Decision[] = [];
   const projectsToCleanUp: Project[] = [];
 
-  const createTestProjectAndDecisions = async (testName: string): Promise<Decision[]> => {
+  // Add sleep function
+  const wait = (ms: number) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+
+  const createTestProjectAndDecisions = async (
+    testName: string,
+  ): Promise<Decision[]> => {
     const randomChars = Math.random().toString(36).substring(5, 9);
-    const emptyDecision = Decision.createEmptyDecision();
     const projectId = `test-${testName}-${randomChars}`;
     const teamId = `team-${testName}-${randomChars}`;
 
-    const project = await projectRepository.create(Project.create({
-      id: projectId,
-      name: `Test Project ${testName}`,
-      description: `Temporary project for integration tests ${testName}`,
-      organisationId: BASE_TEST_SCOPE.organisationId,
-    }));
+    const project = await projectRepository.create(
+      Project.create({
+        id: projectId,
+        name: `Test Project ${testName}`,
+        description: `Temporary project for integration tests ${testName}`,
+        organisationId: BASE_TEST_SCOPE.organisationId,
+      }),
+    );
 
     projectsToCleanUp.push(project);
 
     const decisionScope = {
       organisationId: project.organisationId,
-    }
+    };
+
+    // Create empty decision with the organisation ID already set
+    const emptyDecision = Decision.createEmptyDecision({
+      organisationId: project.organisationId,
+    });
 
     const decisionA = await repository.create(
       emptyDecision
         .with({
-          title: 'Decision A',
+          title: "Decision A",
           teamIds: [teamId],
-          projectIds: [project.id]
+          projectIds: [project.id],
         })
         .withoutId(),
-      decisionScope
+      decisionScope,
     );
 
     decisionsToCleanUp.push(decisionA);
@@ -46,12 +58,12 @@ describe('FirestoreDecisionsRepository Integration Tests', () => {
     const decisionA1 = await repository.create(
       emptyDecision
         .with({
-          title: 'Decision A1',
+          title: "Decision A1",
           teamIds: [teamId],
-          projectIds: [project.id]
+          projectIds: [project.id],
         })
         .withoutId(),
-      decisionScope
+      decisionScope,
     );
 
     decisionsToCleanUp.push(decisionA1);
@@ -59,22 +71,46 @@ describe('FirestoreDecisionsRepository Integration Tests', () => {
     const decisionB = await repository.create(
       emptyDecision
         .with({
-          title: 'Decision B',
+          title: "Decision B",
           teamIds: [teamId],
-          projectIds: [project.id]
+          projectIds: [project.id],
         })
         .withoutId(),
-      decisionScope
+      decisionScope,
     );
 
     decisionsToCleanUp.push(decisionB);
 
+    // Add a delay to ensure data is properly written to Firestore
+    await wait(500);
+
     return [decisionA, decisionA1, decisionB];
-  }
+  };
+
+  const createProjectAndTeam = async (
+    testName: string,
+  ): Promise<[Project, string]> => {
+    const randomChars = Math.random().toString(36).substring(5, 9);
+    const projectId = `test-${testName}-${randomChars}`;
+    const teamId = `team-${testName}-${randomChars}`;
+
+    const project = await projectRepository.create(
+      Project.create({
+        id: projectId,
+        name: `Test Project ${testName}`,
+        description: `Temporary project for integration tests ${testName}`,
+        organisationId: BASE_TEST_SCOPE.organisationId,
+      }),
+    );
+
+    projectsToCleanUp.push(project);
+
+    return [project, teamId];
+  };
 
   beforeAll(async () => {
-    await signInTestUser()
-  })
+    await signInTestUser();
+  });
 
   afterAll(async () => {
     for (const decision of decisionsToCleanUp) {
@@ -85,14 +121,14 @@ describe('FirestoreDecisionsRepository Integration Tests', () => {
     for (const project of projectsToCleanUp) {
       await projectRepository.delete(project);
     }
-  })
+  });
 
-  describe('subscribeToOne', () => {
-    it('should receive updates when a decision title is modified', async () => {
+  describe("subscribeToOne", () => {
+    it("should receive updates when a decision title is modified", async () => {
       const onError = vi.fn();
       let updatesReceived = 0;
       const decisionsReceived: Map<number, Decision | null> = new Map();
-      const [decisionA] = await createTestProjectAndDecisions('subscribeToOne');
+      const [decisionA] = await createTestProjectAndDecisions("subscribeToOne");
 
       // Create a promise that resolves when we get both the initial and updated decision
       const allUpdatesReceived = new Promise<void>((resolve) => {
@@ -114,7 +150,7 @@ describe('FirestoreDecisionsRepository Integration Tests', () => {
             if (updatesReceived === 1) {
               // Make a change to the decision title to trigger an update
               repository.update(
-                decisionA.with({ title: decisionA.title + ' Updated' })
+                decisionA.with({ title: decisionA.title + " Updated" }),
               );
             }
 
@@ -131,20 +167,22 @@ describe('FirestoreDecisionsRepository Integration Tests', () => {
 
       // Initial decision had the original title
       const initialDecision = decisionsReceived.get(1);
-      expect(initialDecision?.title).toBe('Decision A');
+      expect(initialDecision?.title).toBe("Decision A");
 
       // Updated decision has the new title
       const updatedDecision = decisionsReceived.get(2);
-      expect(updatedDecision?.title).toBe('Decision A Updated');
+      expect(updatedDecision?.title).toBe("Decision A Updated");
     });
 
-    it('should receive updates when a relationship is added or removed', async () => {
+    it("should receive updates when a relationship is added or removed", async () => {
       const onError = vi.fn();
       let updatesReceived = 0;
       let hasAddedRelationship = false;
       let hasRemovedRelationship = false;
       const decisionsReceived: Map<number, Decision | null> = new Map();
-      const [decisionA, decisionB] = await createTestProjectAndDecisions('subscribeToOne-relationship');
+      const [decisionA, decisionB] = await createTestProjectAndDecisions(
+        "subscribeToOne-relationship",
+      );
 
       // Create a promise that resolves when we get both the initial and updated decision
       const allUpdatesReceived = new Promise<void>((resolve) => {
@@ -165,34 +203,31 @@ describe('FirestoreDecisionsRepository Integration Tests', () => {
 
             // Wait until we've received the initial update before making any changes
             if (updatesReceived === 1) {
-              console.log('[subscribeToOne] Adding relationship');
-              await repository.addRelationship(
-                decisionA,
-                {
-                  targetDecision: decisionB.toDocumentReference(),
-                  targetDecisionTitle: decisionB.title,
-                  type: 'blocked_by'
-                } as DecisionRelationship
-              );
-              console.log('[subscribeToOne] Relationship added');
+              console.log("[subscribeToOne] Adding relationship");
+              await repository.addRelationship(decisionA, {
+                targetDecision: decisionB.toDocumentReference(),
+                targetDecisionTitle: decisionB.title,
+                type: "blocked_by",
+              } as DecisionRelationship);
+              console.log("[subscribeToOne] Relationship added");
             }
 
             // Check if the relationship was added
-            const currentRelationships = decision?.getRelationshipsByType('blocked_by');
-            console.log(`[subscribeToOne] Update ${updatesReceived} - blocked_by relationships: ${currentRelationships?.length}`);
+            const currentRelationships =
+              decision?.getRelationshipsByType("blocked_by");
+            console.log(
+              `[subscribeToOne] Update ${updatesReceived} - blocked_by relationships: ${currentRelationships?.length}`,
+            );
 
             if (!hasAddedRelationship && currentRelationships?.length === 1) {
               hasAddedRelationship = true;
-              console.log('[subscribeToOne] Removing relationship');
-              await repository.removeRelationship(
-                decisionA,
-                {
-                  targetDecision: decisionB.toDocumentReference(),
-                  targetDecisionTitle: decisionB.title,
-                  type: 'blocked_by'
-                } as DecisionRelationship
-              );
-              console.log('[subscribeToOne] Relationship removed');
+              console.log("[subscribeToOne] Removing relationship");
+              await repository.removeRelationship(decisionA, {
+                targetDecision: decisionB.toDocumentReference(),
+                targetDecisionTitle: decisionB.title,
+                type: "blocked_by",
+              } as DecisionRelationship);
+              console.log("[subscribeToOne] Relationship removed");
             }
 
             if (hasAddedRelationship && currentRelationships?.length === 0) {
@@ -211,27 +246,42 @@ describe('FirestoreDecisionsRepository Integration Tests', () => {
       expect(onError).not.toHaveBeenCalled();
 
       // Find the update where the relationship was added
-      const addedRelationshipUpdate = Array.from(decisionsReceived.entries())
-        .find(([, decision]) => decision?.getRelationshipsByType('blocked_by').length === 1);
+      const addedRelationshipUpdate = Array.from(
+        decisionsReceived.entries(),
+      ).find(
+        ([, decision]) =>
+          decision?.getRelationshipsByType("blocked_by").length === 1,
+      );
       expect(addedRelationshipUpdate).toBeDefined();
       const [, decisionWithRelationship] = addedRelationshipUpdate!;
-      expect(decisionWithRelationship?.getRelationshipsByType('blocked_by')[0].targetDecision.id).toBe(decisionB.id);
-      expect(decisionWithRelationship?.getRelationshipsByType('blocked_by')[0].targetDecisionTitle).toBe(decisionB.title);
+      expect(
+        decisionWithRelationship?.getRelationshipsByType("blocked_by")[0]
+          .targetDecision.id,
+      ).toBe(decisionB.id);
+      expect(
+        decisionWithRelationship?.getRelationshipsByType("blocked_by")[0]
+          .targetDecisionTitle,
+      ).toBe(decisionB.title);
 
       // Find the update where the relationship was removed
-      const removedRelationshipUpdate = Array.from(decisionsReceived.entries())
-        .find(([, decision]) => decision?.getRelationshipsByType('blocked_by').length === 0);
+      const removedRelationshipUpdate = Array.from(
+        decisionsReceived.entries(),
+      ).find(
+        ([, decision]) =>
+          decision?.getRelationshipsByType("blocked_by").length === 0,
+      );
       expect(removedRelationshipUpdate).toBeDefined();
     }, 20000);
   });
 
-  describe('subscribeToAll', () => {
-    it('should receive updates when multiple decision titles are modified', async () => {
+  describe("subscribeToAll", () => {
+    it("should receive updates when multiple decision titles are modified", async () => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const [decisionA, _, decisionB] = await createTestProjectAndDecisions('subscribeToAll');
+      const [decisionA, _, decisionB] =
+        await createTestProjectAndDecisions("subscribeToAll");
       const testProjectScope = {
         organisationId: decisionA.organisationId,
-      }
+      };
 
       const onError = vi.fn();
       let updatesReceived = 0;
@@ -256,7 +306,7 @@ describe('FirestoreDecisionsRepository Integration Tests', () => {
             if (updatesReceived === 1) {
               // Make a change to the decision A
               repository.update(
-                decisionA.with({ title: decisionA.title + ' Updated' })
+                decisionA.with({ title: decisionA.title + " Updated" }),
               );
             }
 
@@ -264,14 +314,14 @@ describe('FirestoreDecisionsRepository Integration Tests', () => {
             if (updatesReceived === 2) {
               // Make a change to the decision B
               repository.update(
-                decisionB.with({ title: decisionB.title + ' Updated' })
+                decisionB.with({ title: decisionB.title + " Updated" }),
               );
             }
 
             checkIfAllUpdatesReceived();
           },
           onError,
-          testProjectScope
+          testProjectScope,
         );
       });
 
@@ -280,25 +330,33 @@ describe('FirestoreDecisionsRepository Integration Tests', () => {
       expect(onError).not.toHaveBeenCalled();
 
       // The first update should contain the initial decisions titles
-      const initialDecision = decisionsReceived.get(1)?.find(d => d.id === decisionA.id);
-      expect(initialDecision?.title).toBe('Decision A');
+      const initialDecision = decisionsReceived
+        .get(1)
+        ?.find((d) => d.id === decisionA.id);
+      expect(initialDecision?.title).toBe("Decision A");
 
       // The second update should contain the updated decision A title
-      const updatedDecision = decisionsReceived.get(2)?.find(d => d.id === decisionA.id);
-      expect(updatedDecision?.title).toBe('Decision A Updated');
+      const updatedDecision = decisionsReceived
+        .get(2)
+        ?.find((d) => d.id === decisionA.id);
+      expect(updatedDecision?.title).toBe("Decision A Updated");
 
       // The third update should contain the updated decision B title
-      const updatedDecisionB = decisionsReceived.get(3)?.find(d => d.id === decisionB.id);
-      expect(updatedDecisionB?.title).toBe('Decision B Updated');
+      const updatedDecisionB = decisionsReceived
+        .get(3)
+        ?.find((d) => d.id === decisionB.id);
+      expect(updatedDecisionB?.title).toBe("Decision B Updated");
     });
 
-    it('should receive to both decisions on both sides of a relationship when a relationship is added or removed', async () => {
+    it("should receive to both decisions on both sides of a relationship when a relationship is added or removed", async () => {
       const onError = vi.fn();
       let updatesReceived = 0;
       let hasAddedRelationship = false;
       let hasRemovedRelationship = false;
       const decisionsReceived: Map<number, Decision[]> = new Map();
-      const [decisionA, decisionB] = await createTestProjectAndDecisions('subscribeToAll-relationship');
+      const [decisionA, decisionB] = await createTestProjectAndDecisions(
+        "subscribeToAll-relationship",
+      );
 
       // Create a promise that resolves when we get both the initial and updated decision
       const allUpdatesReceived = new Promise<void>((resolve) => {
@@ -316,47 +374,55 @@ describe('FirestoreDecisionsRepository Integration Tests', () => {
             console.log(`[subscribeToAll] Received update ${updatesReceived}`);
             decisionsReceived.set(updatesReceived, decisions);
 
-            const currentDecisionA = decisions.find(d => d.id === decisionA.id);
-            const currentDecisionB = decisions.find(d => d.id === decisionB.id);
+            const currentDecisionA = decisions.find(
+              (d) => d.id === decisionA.id,
+            );
+            const currentDecisionB = decisions.find(
+              (d) => d.id === decisionB.id,
+            );
 
-            console.log(`[subscribeToAll] Update ${updatesReceived} - Decision A blocked_by relationships: ${currentDecisionA?.getRelationshipsByType('blocked_by').length}`);
-            console.log(`[subscribeToAll] Update ${updatesReceived} - Decision B blocks relationships: ${currentDecisionB?.getRelationshipsByType('blocks').length}`);
+            console.log(
+              `[subscribeToAll] Update ${updatesReceived} - Decision A blocked_by relationships: ${currentDecisionA?.getRelationshipsByType("blocked_by").length}`,
+            );
+            console.log(
+              `[subscribeToAll] Update ${updatesReceived} - Decision B blocks relationships: ${currentDecisionB?.getRelationshipsByType("blocks").length}`,
+            );
 
             // Wait until we've received the initial update before making any changes
             if (updatesReceived === 1) {
-              console.log('[subscribeToAll] Adding relationship');
-              await repository.addRelationship(
-                decisionA,
-                {
-                  targetDecision: decisionB.toDocumentReference(),
-                  targetDecisionTitle: decisionB.title,
-                  type: 'blocked_by'
-                } as DecisionRelationship
-              );
-              console.log('[subscribeToAll] Relationship added');
+              console.log("[subscribeToAll] Adding relationship");
+              await repository.addRelationship(decisionA, {
+                targetDecision: decisionB.toDocumentReference(),
+                targetDecisionTitle: decisionB.title,
+                type: "blocked_by",
+              } as DecisionRelationship);
+              console.log("[subscribeToAll] Relationship added");
             }
 
             // Check if both relationships have been added
-            if (!hasAddedRelationship &&
-                currentDecisionA?.getRelationshipsByType('blocked_by').length === 1 &&
-                currentDecisionB?.getRelationshipsByType('blocks').length === 1) {
+            if (
+              !hasAddedRelationship &&
+              currentDecisionA?.getRelationshipsByType("blocked_by").length ===
+                1 &&
+              currentDecisionB?.getRelationshipsByType("blocks").length === 1
+            ) {
               hasAddedRelationship = true;
-              console.log('[subscribeToAll] Removing relationship');
-              await repository.removeRelationship(
-                decisionA,
-                {
-                  targetDecision: decisionB.toDocumentReference(),
-                  targetDecisionTitle: decisionB.title,
-                  type: 'blocked_by'
-                } as DecisionRelationship
-              );
-              console.log('[subscribeToAll] Relationship removed');
+              console.log("[subscribeToAll] Removing relationship");
+              await repository.removeRelationship(decisionA, {
+                targetDecision: decisionB.toDocumentReference(),
+                targetDecisionTitle: decisionB.title,
+                type: "blocked_by",
+              } as DecisionRelationship);
+              console.log("[subscribeToAll] Relationship removed");
             }
 
             // Check if both relationships have been removed
-            if (hasAddedRelationship &&
-                currentDecisionA?.getRelationshipsByType('blocked_by').length === 0 &&
-                currentDecisionB?.getRelationshipsByType('blocks').length === 0) {
+            if (
+              hasAddedRelationship &&
+              currentDecisionA?.getRelationshipsByType("blocked_by").length ===
+                0 &&
+              currentDecisionB?.getRelationshipsByType("blocks").length === 0
+            ) {
               hasRemovedRelationship = true;
             }
 
@@ -365,7 +431,7 @@ describe('FirestoreDecisionsRepository Integration Tests', () => {
           onError,
           {
             organisationId: decisionA.organisationId,
-          }
+          },
         );
       });
 
@@ -375,54 +441,69 @@ describe('FirestoreDecisionsRepository Integration Tests', () => {
       expect(onError).not.toHaveBeenCalled();
 
       // Find the update where both relationships were added
-      const addedRelationshipUpdate = Array.from(decisionsReceived.entries())
-        .find(([, decisions]) => {
-          const foundDecisionA = decisions.find(d => d.id === decisionA.id);
-          const foundDecisionB = decisions.find(d => d.id === decisionB.id);
-          return foundDecisionA?.getRelationshipsByType('blocked_by').length === 1 &&
-                 foundDecisionB?.getRelationshipsByType('blocks').length === 1;
-        });
+      const addedRelationshipUpdate = Array.from(
+        decisionsReceived.entries(),
+      ).find(([, decisions]) => {
+        const foundDecisionA = decisions.find((d) => d.id === decisionA.id);
+        const foundDecisionB = decisions.find((d) => d.id === decisionB.id);
+        return (
+          foundDecisionA?.getRelationshipsByType("blocked_by").length === 1 &&
+          foundDecisionB?.getRelationshipsByType("blocks").length === 1
+        );
+      });
       expect(addedRelationshipUpdate).toBeDefined();
       const [, decisionsWithRelationship] = addedRelationshipUpdate!;
-      const decisionAWithRelationship = decisionsWithRelationship.find(d => d.id === decisionA.id);
-      const decisionBWithRelationship = decisionsWithRelationship.find(d => d.id === decisionB.id);
-      expect(decisionAWithRelationship?.getRelationshipsByType('blocked_by')[0].targetDecision.id).toBe(decisionB.id);
-      expect(decisionAWithRelationship?.getRelationshipsByType('blocked_by')[0].targetDecisionTitle).toBe(decisionB.title);
-      expect(decisionBWithRelationship?.getRelationshipsByType('blocks')[0].targetDecision.id).toBe(decisionA.id);
-      expect(decisionBWithRelationship?.getRelationshipsByType('blocks')[0].targetDecisionTitle).toBe(decisionA.title);
+      const decisionAWithRelationship = decisionsWithRelationship.find(
+        (d) => d.id === decisionA.id,
+      );
+      const decisionBWithRelationship = decisionsWithRelationship.find(
+        (d) => d.id === decisionB.id,
+      );
+      expect(
+        decisionAWithRelationship?.getRelationshipsByType("blocked_by")[0]
+          .targetDecision.id,
+      ).toBe(decisionB.id);
+      expect(
+        decisionAWithRelationship?.getRelationshipsByType("blocked_by")[0]
+          .targetDecisionTitle,
+      ).toBe(decisionB.title);
+      expect(
+        decisionBWithRelationship?.getRelationshipsByType("blocks")[0]
+          .targetDecision.id,
+      ).toBe(decisionA.id);
+      expect(
+        decisionBWithRelationship?.getRelationshipsByType("blocks")[0]
+          .targetDecisionTitle,
+      ).toBe(decisionA.title);
 
       // Find the update where both relationships were removed
-      const removedRelationshipUpdate = Array.from(decisionsReceived.entries())
-        .find(([, decisions]) => {
-          const foundDecisionA = decisions.find(d => d.id === decisionA.id);
-          const foundDecisionB = decisions.find(d => d.id === decisionB.id);
-          return foundDecisionA?.getRelationshipsByType('blocked_by').length === 0 &&
-                 foundDecisionB?.getRelationshipsByType('blocks').length === 0;
-        });
+      const removedRelationshipUpdate = Array.from(
+        decisionsReceived.entries(),
+      ).find(([, decisions]) => {
+        const foundDecisionA = decisions.find((d) => d.id === decisionA.id);
+        const foundDecisionB = decisions.find((d) => d.id === decisionB.id);
+        return (
+          foundDecisionA?.getRelationshipsByType("blocked_by").length === 0 &&
+          foundDecisionB?.getRelationshipsByType("blocks").length === 0
+        );
+      });
       expect(removedRelationshipUpdate).toBeDefined();
-    }, 20000);
+    }, 30000);
   });
 
-  describe('newline preservation', () => {
-    it('should preserve empty lines in markdown content', async () => {
-      const testName = 'newline-preservation';
-      const emptyDecision = Decision.createEmptyDecision();
-      const randomChars = Math.random().toString(36).substring(5, 9);
-      const projectId = `test-${testName}-${randomChars}`;
-      const teamId = `team-${testName}-${randomChars}`;
-
-      const project = await projectRepository.create(Project.create({
-        id: projectId,
-        name: `Test Project ${testName}`,
-        description: `Temporary project for integration tests ${testName}`,
-        organisationId: BASE_TEST_SCOPE.organisationId,
-      }));
-
-      projectsToCleanUp.push(project);
-
+  describe("newline preservation", () => {
+    it("should preserve empty lines in markdown content", async () => {
+      const [project, teamId] = await createProjectAndTeam(
+        "newlinePreservation",
+      );
       const decisionScope = {
         organisationId: project.organisationId,
-      }
+      };
+
+      // Create an empty decision with the organisation ID
+      const emptyDecision = Decision.createEmptyDecision({
+        organisationId: project.organisationId,
+      });
 
       // Create a decision with markdown content containing multiple empty lines
       const markdownWithEmptyLines = `# Title
@@ -439,77 +520,140 @@ This is another paragraph after two empty lines.
       const decision = await repository.create(
         emptyDecision
           .with({
-            title: 'Decision with empty lines',
+            title: "Decision with empty lines",
             description: markdownWithEmptyLines,
             teamIds: [teamId],
-            projectIds: [project.id]
+            projectIds: [project.id],
           })
           .withoutId(),
-        decisionScope
+        decisionScope,
       );
 
       decisionsToCleanUp.push(decision);
 
+      // Add a delay to ensure data is properly written to Firestore
+      await wait(500);
+
       // Retrieve the decision and check if empty lines are preserved
-      const retrievedDecision = await repository.getById(decision.id, decisionScope);
+      const retrievedDecision = await repository.getById(
+        decision.id,
+        decisionScope,
+      );
 
       expect(retrievedDecision.description).toBe(markdownWithEmptyLines);
 
       // Specifically check for the double newlines
-      expect(retrievedDecision.description).toContain('paragraph.\n\n\nThis');
-      expect(retrievedDecision.description).toContain('item 1\n\n* List');
+      expect(retrievedDecision.description).toContain("paragraph.\n\n\nThis");
+      expect(retrievedDecision.description).toContain("item 1\n\n* List");
     });
   });
 
-  describe('Relationship Management', () => {
-    it('should add and remove relationships correctly', async () => {
+  describe("Relationship Management", () => {
+    it("should add and remove relationships correctly", async () => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const [decisionA, _, decisionB] = await createTestProjectAndDecisions('relationshipManagement');
+      const [decisionA, _, decisionB] = await createTestProjectAndDecisions(
+        "relationshipManagement",
+      );
       const testProjectScope = {
         organisationId: decisionA.organisationId,
-      }
+      };
 
       // Add a relationship
-      await repository.addRelationship(
-        decisionA,
-        {
-          targetDecision: decisionB.toDocumentReference(),
-          targetDecisionTitle: decisionB.title,
-          type: 'blocked_by'
-        } as DecisionRelationship
-      );
+      await repository.addRelationship(decisionA, {
+        targetDecision: decisionB.toDocumentReference(),
+        targetDecisionTitle: decisionB.title,
+        type: "blocked_by",
+      } as DecisionRelationship);
 
       // Verify the relationship was added
-      const decisionWithRelationship = await repository.getById(decisionA.id, testProjectScope);
-      const relationships = decisionWithRelationship.getRelationshipsByType('blocked_by');
+      const decisionWithRelationship = await repository.getById(
+        decisionA.id,
+        testProjectScope,
+      );
+      const relationships =
+        decisionWithRelationship.getRelationshipsByType("blocked_by");
       expect(relationships).toHaveLength(1);
       expect(relationships[0].targetDecision.id).toBe(decisionB.id);
-      expect(relationships[0].targetDecisionTitle).toBe('Decision B');
+      expect(relationships[0].targetDecisionTitle).toBe("Decision B");
 
       // Verify the inverse relationship was added
-      const targetDecision = await repository.getById(decisionB.id, testProjectScope);
-      const inverseRelationships = targetDecision.getRelationshipsByType('blocks');
+      const targetDecision = await repository.getById(
+        decisionB.id,
+        testProjectScope,
+      );
+      const inverseRelationships =
+        targetDecision.getRelationshipsByType("blocks");
       expect(inverseRelationships).toHaveLength(1);
       expect(inverseRelationships[0].targetDecision.id).toBe(decisionA.id);
-      expect(inverseRelationships[0].targetDecisionTitle).toBe('Decision A');
+      expect(inverseRelationships[0].targetDecisionTitle).toBe("Decision A");
 
       // Remove the relationship
-      await repository.removeRelationship(
-        decisionA,
-        {
-          targetDecision: decisionB.toDocumentReference(),
-          targetDecisionTitle: decisionB.title,
-          type: 'blocked_by'
-        } as DecisionRelationship
-      );
+      await repository.removeRelationship(decisionA, {
+        targetDecision: decisionB.toDocumentReference(),
+        targetDecisionTitle: decisionB.title,
+        type: "blocked_by",
+      } as DecisionRelationship);
 
       // Verify the relationship was removed
-      const decisionWithoutRelationship = await repository.getById(decisionA.id, testProjectScope);
-      expect(decisionWithoutRelationship.getRelationshipsByType('blocked_by')).toHaveLength(0);
+      const decisionWithoutRelationship = await repository.getById(
+        decisionA.id,
+        testProjectScope,
+      );
+      expect(
+        decisionWithoutRelationship.getRelationshipsByType("blocked_by"),
+      ).toHaveLength(0);
 
       // Verify the inverse relationship was removed
-      const targetDecisionAfterRemoval = await repository.getById(decisionB.id, testProjectScope);
-      expect(targetDecisionAfterRemoval.getRelationshipsByType('blocks')).toHaveLength(0);
-    });
+      const targetDecisionAfterRemoval = await repository.getById(
+        decisionB.id,
+        testProjectScope,
+      );
+      expect(
+        targetDecisionAfterRemoval.getRelationshipsByType("blocks"),
+      ).toHaveLength(0);
+    }, 30000);
+
+    it("should update bidirectional relationships when publishing a decision", async () => {
+      // Create test decisions
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const [decisionA, _, decisionB] = await createTestProjectAndDecisions(
+        "relationshipPublishing",
+      );
+      const testProjectScope = {
+        organisationId: decisionA.organisationId,
+      };
+
+      // Add a blocks relationship
+      await repository.addRelationship(decisionA, {
+        targetDecision: decisionB.toDocumentReference(),
+        targetDecisionTitle: decisionB.title,
+        type: "blocks",
+      } as DecisionRelationship);
+
+      // Publish decision A
+      await repository.publish(decisionA);
+
+      // Verify the relationship was transformed on decision A
+      const updatedDecisionA = await repository.getById(
+        decisionA.id,
+        testProjectScope,
+      );
+      const relationshipsA =
+        updatedDecisionA.getRelationshipsByType("did_block");
+      expect(relationshipsA).toHaveLength(1);
+      expect(relationshipsA[0].targetDecision.id).toBe(decisionB.id);
+      expect(relationshipsA[0].targetDecisionTitle).toBe("Decision B");
+
+      // Verify the inverse relationship was transformed on decision B
+      const updatedDecisionB = await repository.getById(
+        decisionB.id,
+        testProjectScope,
+      );
+      const relationshipsB =
+        updatedDecisionB.getRelationshipsByType("was_blocked_by");
+      expect(relationshipsB).toHaveLength(1);
+      expect(relationshipsB[0].targetDecision.id).toBe(decisionA.id);
+      expect(relationshipsB[0].targetDecisionTitle).toBe("Decision A");
+    }, 10000);
   });
-})
+});

--- a/lib/infrastructure/firestoreDecisionsRepository.ts
+++ b/lib/infrastructure/firestoreDecisionsRepository.ts
@@ -95,7 +95,7 @@ export class FirestoreDecisionsRepository implements DecisionsRepository {
     return this.decisionFromFirestore(docSnap)
   }
 
-  async create(scope: DecisionScope, initialData: Partial<DecisionProps> = {}): Promise<Decision> {
+  async create(initialData: Partial<DecisionProps> = {}, scope: DecisionScope): Promise<Decision> {
     const docRef = doc(collection(db, this.getDecisionPath(scope)))
 
     const data: Record<string, string | string[] | null | FieldValue | Record<string, unknown> | DecisionStakeholderRole[] | SupportingMaterial[]> = {

--- a/lib/infrastructure/firestoreDecisionsRepository.ts
+++ b/lib/infrastructure/firestoreDecisionsRepository.ts
@@ -2,8 +2,14 @@ import {
   DecisionsRepository,
   DecisionScope,
 } from "@/lib/domain/decisionsRepository";
-import { Decision, DecisionProps, DecisionStakeholderRole, DecisionRelationship, DecisionRelationshipTools } from "@/lib/domain/Decision";
-import { SupportingMaterial } from '@/lib/domain/SupportingMaterial';
+import {
+  Decision,
+  DecisionProps,
+  DecisionStakeholderRole,
+  DecisionRelationship,
+  DecisionRelationshipTools,
+} from "@/lib/domain/Decision";
+import { SupportingMaterial } from "@/lib/domain/SupportingMaterial";
 import { db } from "@/lib/firebase";
 import {
   collection,
@@ -26,104 +32,129 @@ import {
 import { DecisionRelationshipError } from "@/lib/domain/DecisionError";
 
 export class FirestoreDecisionsRepository implements DecisionsRepository {
-
   private getDecisionPath(scope: DecisionScope) {
-    return `organisations/${scope.organisationId}/decisions`
+    if (!scope.organisationId) {
+      throw new Error("Cannot get decision path: organisationId is required");
+    }
+    return `organisations/${scope.organisationId}/decisions`;
   }
 
-  private getDecisionCollectionPathFromDecision(decision: Decision) {
-    return `organisations/${decision.organisationId}/decisions`
+  private getDecisionCollectionPathFromDecision(decision: Decision): string {
+    return `organisations/${decision.organisationId}/decisions`;
   }
 
-  private decisionFromFirestore(doc: QueryDocumentSnapshot<DocumentData>): Decision {
+  private decisionFromFirestore(
+    doc: QueryDocumentSnapshot<DocumentData>,
+  ): Decision {
     const data = doc.data();
     const props: DecisionProps = {
       id: doc.id,
-      title: data.title || '',
-      description: data.description || '',
-      cost: data.cost || 'low',
+      title: data.title || "",
+      description: data.description || "",
+      cost: data.cost || "low",
       decision: data.decision,
       decisionMethod: data.decisionMethod,
-      reversibility: data.reversibility || 'haircut',
+      reversibility: data.reversibility || "haircut",
       stakeholders: data.stakeholders || [],
-      driverStakeholderId: data.driverStakeholderId || '',
+      driverStakeholderId: data.driverStakeholderId || "",
       supportingMaterials: data.supportingMaterials || [],
-      createdAt: data.createdAt ? (data.createdAt as unknown as Timestamp).toDate() : new Date(),
-      updatedAt: data.updatedAt ? (data.updatedAt as unknown as Timestamp).toDate() : new Date(),
-      publishDate: data.publishDate ? (data.publishDate as unknown as Timestamp).toDate() : undefined,
+      createdAt: data.createdAt
+        ? (data.createdAt as unknown as Timestamp).toDate()
+        : new Date(),
+      updatedAt: data.updatedAt
+        ? (data.updatedAt as unknown as Timestamp).toDate()
+        : new Date(),
+      publishDate: data.publishDate
+        ? (data.publishDate as unknown as Timestamp).toDate()
+        : undefined,
       organisationId: data.organisationId,
       teamIds: data.teamIds || [],
       projectIds: data.projectIds || [],
       relationships: data.relationships || {},
-      decisionNotes: data.decisionNotes || '',
+      decisionNotes: data.decisionNotes || "",
     };
     return Decision.create(props);
   }
 
   async getAll(scope: DecisionScope): Promise<Decision[]> {
-    const q = collection(db, this.getDecisionPath(scope))
-    const querySnapshot = await getDocs(q)
-    return querySnapshot.docs.map(doc => this.decisionFromFirestore(doc))
+    const q = collection(db, this.getDecisionPath(scope));
+    const querySnapshot = await getDocs(q);
+    return querySnapshot.docs.map((doc) => this.decisionFromFirestore(doc));
   }
 
   async getByTeam(teamId: string, scope: DecisionScope): Promise<Decision[]> {
     const q = query(
       collection(db, this.getDecisionPath(scope)),
-      where('teamIds', 'array-contains', teamId)
+      where("teamIds", "array-contains", teamId),
     );
     const querySnapshot = await getDocs(q);
-    return querySnapshot.docs.map(doc => this.decisionFromFirestore(doc));
+    return querySnapshot.docs.map((doc) => this.decisionFromFirestore(doc));
   }
 
-  async getByProject(projectId: string, scope: DecisionScope): Promise<Decision[]> {
+  async getByProject(
+    projectId: string,
+    scope: DecisionScope,
+  ): Promise<Decision[]> {
     const q = query(
       collection(db, this.getDecisionPath(scope)),
-      where('projectIds', 'array-contains', projectId)
+      where("projectIds", "array-contains", projectId),
     );
     const querySnapshot = await getDocs(q);
-    return querySnapshot.docs.map(doc => this.decisionFromFirestore(doc));
+    return querySnapshot.docs.map((doc) => this.decisionFromFirestore(doc));
   }
 
   async getById(id: string, scope: DecisionScope): Promise<Decision> {
-    const docRef = doc(db, this.getDecisionPath(scope), id)
-    const docSnap = await getDoc(docRef)
+    const docRef = doc(db, this.getDecisionPath(scope), id);
+    const docSnap = await getDoc(docRef);
 
     if (!docSnap.exists()) {
-      throw new Error(`Decision with id ${id} not found`)
+      throw new Error(`Decision with id ${id} not found`);
     }
 
-    return this.decisionFromFirestore(docSnap)
+    return this.decisionFromFirestore(docSnap);
   }
 
-  async create(initialData: Partial<DecisionProps> = {}, scope: DecisionScope): Promise<Decision> {
-    const docRef = doc(collection(db, this.getDecisionPath(scope)))
+  async create(
+    initialData: Partial<DecisionProps> = {},
+    scope: DecisionScope,
+  ): Promise<Decision> {
+    const docRef = doc(collection(db, this.getDecisionPath(scope)));
 
-    const data: Record<string, string | string[] | null | FieldValue | Record<string, unknown> | DecisionStakeholderRole[] | SupportingMaterial[]> = {
-      title: initialData.title ?? '',
-      description: initialData.description ?? '',
-      cost: initialData.cost ?? 'low',
+    const data: Record<
+      string,
+      | string
+      | string[]
+      | null
+      | FieldValue
+      | Record<string, unknown>
+      | DecisionStakeholderRole[]
+      | SupportingMaterial[]
+    > = {
+      title: initialData.title ?? "",
+      description: initialData.description ?? "",
+      cost: initialData.cost ?? "low",
       decision: initialData.decision ?? null,
       decisionMethod: initialData.decisionMethod ?? null,
-      reversibility: initialData.reversibility ?? 'hat',
+      reversibility: initialData.reversibility ?? "hat",
       stakeholders: initialData.stakeholders ?? [],
-      driverStakeholderId: initialData.driverStakeholderId ?? '',
+      driverStakeholderId: initialData.driverStakeholderId ?? "",
       supportingMaterials: initialData.supportingMaterials ?? [],
       organisationId: scope.organisationId,
       teamIds: initialData.teamIds ?? [],
       projectIds: initialData.projectIds ?? [],
-      decisionNotes: initialData.decisionNotes ?? '',
+      decisionNotes: initialData.decisionNotes ?? "",
       createdAt: serverTimestamp(),
       updatedAt: serverTimestamp(),
-    }
+    };
 
     // Filter out any undefined values
     const filteredData = Object.fromEntries(
-      Object.entries(data).filter(([, value]) => value !== undefined)
+      Object.entries(data).filter(([, value]) => value !== undefined),
     );
 
-    await setDoc(docRef, filteredData)
+    await setDoc(docRef, filteredData);
 
-    return this.getById(docRef.id, scope)
+    return this.getById(docRef.id, scope);
   }
 
   async update(decision: Decision): Promise<void> {
@@ -131,7 +162,7 @@ export class FirestoreDecisionsRepository implements DecisionsRepository {
       organisationId: decision.organisationId,
     };
 
-    const docRef = doc(db, this.getDecisionPath(scope), decision.id)
+    const docRef = doc(db, this.getDecisionPath(scope), decision.id);
 
     const data: Record<string, FieldValue | Partial<unknown> | undefined> = {
       title: decision.title,
@@ -148,36 +179,38 @@ export class FirestoreDecisionsRepository implements DecisionsRepository {
       projectIds: decision.projectIds,
       publishDate: decision.publishDate,
       decisionNotes: decision.decisionNotes,
-      updatedAt: serverTimestamp()
-    }
+      updatedAt: serverTimestamp(),
+    };
 
     // Filter out any undefined values
     const filteredData = Object.fromEntries(
-      Object.entries(data).filter(([, value]) => value !== undefined)
+      Object.entries(data).filter(([, value]) => value !== undefined),
     );
 
-    await updateDoc(docRef, filteredData)
+    await updateDoc(docRef, filteredData);
   }
 
   async delete(id: string, scope: DecisionScope): Promise<void> {
-    const docRef = doc(db, this.getDecisionPath(scope), id)
-    await deleteDoc(docRef)
+    const docRef = doc(db, this.getDecisionPath(scope), id);
+    await deleteDoc(docRef);
   }
 
   subscribeToAll(
     onData: (decisions: Decision[]) => void,
     onError: (error: Error) => void,
-    scope: DecisionScope
+    scope: DecisionScope,
   ): () => void {
     const q = collection(db, this.getDecisionPath(scope));
 
     return onSnapshot(
       q,
       (snapshot) => {
-        const decisions = snapshot.docs.map(doc => this.decisionFromFirestore(doc));
+        const decisions = snapshot.docs.map((doc) =>
+          this.decisionFromFirestore(doc),
+        );
         onData(decisions);
       },
-      onError
+      onError,
     );
   }
 
@@ -202,16 +235,34 @@ export class FirestoreDecisionsRepository implements DecisionsRepository {
           onData(null);
         }
       },
-      onError
+      onError,
     );
   }
 
-  private async getDecisionFromDecisionRelationship(decisionRelationship: DecisionRelationship): Promise<Decision> {
-    const targetDecisionDoc = await getDoc(doc(db, decisionRelationship.targetDecision.path));
+  private async getDecisionFromDecisionRelationship(
+    decisionRelationship: DecisionRelationship,
+  ): Promise<Decision> {
+    const organisationId =
+      DecisionRelationshipTools.getTargetDecisionOrganisationId(
+        decisionRelationship,
+      );
+    const targetDecisionDoc = await getDoc(
+      doc(
+        db,
+        "organisations",
+        organisationId,
+        "decisions",
+        decisionRelationship.targetDecision.id,
+      ),
+    );
     if (!targetDecisionDoc.exists()) {
-      throw new DecisionRelationshipError(`Decision relationship target decision ${decisionRelationship.targetDecision} not found`);
+      throw new DecisionRelationshipError(
+        `Decision relationship target decision ${decisionRelationship.targetDecision.id} not found`,
+      );
     }
-    return this.decisionFromFirestore(targetDecisionDoc as QueryDocumentSnapshot<DocumentData>);
+    return this.decisionFromFirestore(
+      targetDecisionDoc as QueryDocumentSnapshot<DocumentData>,
+    );
   }
 
   private updateDecisionRelationships(
@@ -219,49 +270,82 @@ export class FirestoreDecisionsRepository implements DecisionsRepository {
     decision: Decision,
     relationships: Record<string, unknown> | undefined,
   ): void {
-    const decisionRef = doc(db, this.getDecisionCollectionPathFromDecision(decision), decision.id);
+    const decisionRef = doc(
+      db,
+      this.getDecisionCollectionPathFromDecision(decision),
+      decision.id,
+    );
     batch.update(decisionRef, {
       relationships: relationships || {},
-      updatedAt: serverTimestamp()
+      updatedAt: serverTimestamp(),
     });
   }
 
   private async applyBidirectionalRelationshipChange(
     sourceDecision: Decision,
     targetDecisionRelationship: DecisionRelationship,
-    operation: 'add' | 'remove'
+    operation: "add" | "remove",
   ): Promise<void> {
     // Validate the relationship if we're adding i
-    if (operation === 'add') {
+    if (operation === "add") {
       if (sourceDecision.id === targetDecisionRelationship.targetDecision.id) {
-        throw new DecisionRelationshipError('A decision cannot have a relationship with itself');
+        throw new DecisionRelationshipError(
+          "A decision cannot have a relationship with itself",
+        );
       }
 
-      if (sourceDecision.organisationId !== DecisionRelationshipTools.getTargetDecisionOrganisationId(targetDecisionRelationship)) {
-        throw new DecisionRelationshipError('Decisions must belong to the same organisation');
+      if (
+        sourceDecision.organisationId !==
+        DecisionRelationshipTools.getTargetDecisionOrganisationId(
+          targetDecisionRelationship,
+        )
+      ) {
+        throw new DecisionRelationshipError(
+          "Decisions must belong to the same organisation",
+        );
       }
     }
 
     // Get the target decision
-    const targetDecision = await this.getDecisionFromDecisionRelationship(targetDecisionRelationship);
+    const targetDecision = await this.getDecisionFromDecisionRelationship(
+      targetDecisionRelationship,
+    );
 
     // Get the inverse relationship type
-    const inverseType = DecisionRelationshipTools.getInverseRelationshipType(targetDecisionRelationship.type);
+    const inverseType = DecisionRelationshipTools.getInverseRelationshipType(
+      targetDecisionRelationship.type,
+    );
 
     // Create a batch write
     const batch = writeBatch(db);
 
     // Update source decision relationships
-    const updatedSourceDecision = operation === 'add'
-      ? sourceDecision.setRelationship(targetDecisionRelationship.type, targetDecision)
-      : sourceDecision.unsetRelationship(targetDecisionRelationship.type, targetDecisionRelationship.targetDecision.id);
-    this.updateDecisionRelationships(batch, sourceDecision, updatedSourceDecision.relationships);
+    const updatedSourceDecision =
+      operation === "add"
+        ? sourceDecision.setRelationship(
+            targetDecisionRelationship.type,
+            targetDecision,
+          )
+        : sourceDecision.unsetRelationship(
+            targetDecisionRelationship.type,
+            targetDecisionRelationship.targetDecision.id,
+          );
+    this.updateDecisionRelationships(
+      batch,
+      sourceDecision,
+      updatedSourceDecision.relationships,
+    );
 
     // Update target decision relationships
-    const updatedTargetDecision = operation === 'add'
-      ? targetDecision.setRelationship(inverseType, sourceDecision)
-      : targetDecision.unsetRelationship(inverseType, sourceDecision.id);
-    this.updateDecisionRelationships(batch, targetDecision, updatedTargetDecision.relationships);
+    const updatedTargetDecision =
+      operation === "add"
+        ? targetDecision.setRelationship(inverseType, sourceDecision)
+        : targetDecision.unsetRelationship(inverseType, sourceDecision.id);
+    this.updateDecisionRelationships(
+      batch,
+      targetDecision,
+      updatedTargetDecision.relationships,
+    );
 
     // Commit the batch
     await batch.commit();
@@ -271,13 +355,194 @@ export class FirestoreDecisionsRepository implements DecisionsRepository {
     sourceDecision: Decision,
     targetDecisionRelationship: DecisionRelationship,
   ): Promise<void> {
-    await this.applyBidirectionalRelationshipChange(sourceDecision, targetDecisionRelationship, 'add');
+    await this.applyBidirectionalRelationshipChange(
+      sourceDecision,
+      targetDecisionRelationship,
+      "add",
+    );
   }
 
   async removeRelationship(
     sourceDecision: Decision,
     targetDecisionRelationship: DecisionRelationship,
   ): Promise<void> {
-    await this.applyBidirectionalRelationshipChange(sourceDecision, targetDecisionRelationship, 'remove');
+    await this.applyBidirectionalRelationshipChange(
+      sourceDecision,
+      targetDecisionRelationship,
+      "remove",
+    );
+  }
+
+  /**
+   * Publishes a decision and updates relationship types on both sides.
+   * - Transforms 'blocks' to 'did_block' on the published decision
+   * - Transforms 'blocked_by' to 'was_blocked_by' on target decisions
+   */
+  async publishDecision(
+    decisionId: string,
+    scope: DecisionScope,
+  ): Promise<Decision> {
+    // 1. Get the decision to publish
+    const decision = await this.getById(decisionId, scope);
+
+    if (!decision) {
+      throw new Error(`Decision with id ${decisionId} not found`);
+    }
+
+    // 2. Get blocks relationships that need to be transformed on target decisions
+    const blocksRelationships = decision.getRelationshipsByType("blocks");
+
+    // 3. Publish the decision (which transforms blocks→did_block on the decision itself)
+    const publishedDecision = decision.publish();
+
+    // 4. Update the published decision in Firestore
+    await this.update(publishedDecision);
+
+    // 5. Update all the target decisions that were previously blocked
+    const batch = writeBatch(db);
+
+    for (const relationship of blocksRelationships) {
+      try {
+        // Get the target decision that was blocked
+        const targetDecision =
+          await this.getDecisionFromDecisionRelationship(relationship);
+
+        if (targetDecision && targetDecision.relationships) {
+          // Get the key for the blocked_by relationship
+          const oldKey = targetDecision.getRelationshipKey(
+            "blocked_by",
+            decisionId,
+          );
+
+          // If the relationship exists, transform it to was_blocked_by
+          if (targetDecision.relationships[oldKey]) {
+            const oldRelationship = targetDecision.relationships[oldKey];
+
+            // Create updated relationships map with the transformed relationship
+            const updatedRelationships = { ...targetDecision.relationships };
+
+            // Remove the old relationship
+            delete updatedRelationships[oldKey];
+
+            // Add the new relationship
+            const newKey = targetDecision.getRelationshipKey(
+              "was_blocked_by",
+              decisionId,
+            );
+            updatedRelationships[newKey] = {
+              ...oldRelationship,
+              type: "was_blocked_by",
+            };
+
+            // Update the relationship in the batch
+            this.updateDecisionRelationships(
+              batch,
+              targetDecision,
+              updatedRelationships,
+            );
+          }
+        }
+      } catch (error) {
+        console.error(
+          `Error updating relationship for target decision: ${error}`,
+        );
+      }
+    }
+
+    // Commit all the batched updates
+    if (blocksRelationships.length > 0) {
+      await batch.commit();
+    }
+
+    return publishedDecision;
+  }
+
+  async publish(decision: Decision): Promise<Decision> {
+    // Get a fresh copy of the decision to ensure we have the latest relationships
+    const freshDecision = await this.getById(decision.id, {
+      organisationId: decision.organisationId,
+    });
+
+    // Start a batch write
+    const batch = writeBatch(db);
+
+    // Get all the decisions that this decision blocks
+    const blocksRelationships = freshDecision.getRelationshipsByType("blocks");
+
+    // Update the source decision's publish date and transform its "blocks" relationships to "did_block"
+    const updatedRelationships = { ...freshDecision.relationships };
+    for (const relationship of blocksRelationships) {
+      // Find all keys that point to this relationship
+      const keys = Object.entries(freshDecision.relationships || {})
+        .filter(
+          ([_, rel]) =>
+            rel.targetDecision.id === relationship.targetDecision.id &&
+            rel.type === "blocks",
+        )
+        .map(([key]) => key);
+
+      // Update each key to use the new relationship type
+      for (const key of keys) {
+        updatedRelationships[key] = {
+          ...relationship,
+          type: "did_block",
+        };
+      }
+    }
+
+    const decisionRef = doc(
+      db,
+      this.getDecisionCollectionPathFromDecision(freshDecision),
+      freshDecision.id,
+    );
+    batch.update(decisionRef, {
+      publishDate: serverTimestamp(),
+      relationships: updatedRelationships,
+      updatedAt: serverTimestamp(),
+    });
+
+    // Update all target decisions to transform their "blocked_by" relationships to "was_blocked_by"
+    for (const relationship of blocksRelationships) {
+      const targetDecision =
+        await this.getDecisionFromDecisionRelationship(relationship);
+      const targetRelationships = { ...targetDecision.relationships };
+
+      // Find all keys that point to this relationship
+      const inverseKeys = Object.entries(targetRelationships)
+        .filter(
+          ([_, rel]) =>
+            rel.targetDecision.id === freshDecision.id &&
+            rel.type === "blocked_by",
+        )
+        .map(([key]) => key);
+
+      // Update each key to use the new relationship type
+      for (const key of inverseKeys) {
+        targetRelationships[key] = {
+          ...targetRelationships[key],
+          type: "was_blocked_by",
+        };
+      }
+
+      if (inverseKeys.length > 0) {
+        const targetRef = doc(
+          db,
+          this.getDecisionCollectionPathFromDecision(targetDecision),
+          targetDecision.id,
+        );
+        batch.update(targetRef, {
+          relationships: targetRelationships,
+          updatedAt: serverTimestamp(),
+        });
+      }
+    }
+
+    // Commit all the updates
+    await batch.commit();
+
+    // Return the updated decision
+    return this.getById(freshDecision.id, {
+      organisationId: freshDecision.organisationId,
+    });
   }
 }


### PR DESCRIPTION
When a decision is published, all its "blocks" relationships change to "did_block", and the corresponding "blocked_by" relationships in other decisions change to "was_blocked_by"